### PR TITLE
Moar team meta

### DIFF
--- a/src/receiver/middleware/lookup-tokens.js
+++ b/src/receiver/middleware/lookup-tokens.js
@@ -23,7 +23,7 @@ module.exports = (options) => {
       bot_token: req.headers['bb-slackbotaccesstoken'],
       // userID of the bot user of the app
       bot_user_id: req.headers['bb-slackbotuserid'],
-      // additional team meta-data
+      // additional bot and team meta-data
       bot_user_name: req.headers['bb-slackbotusername'],
       team_name: req.headers['bb-slackteamname'],
       team_domain: req.headers['bb-slackteamdomain']

--- a/src/receiver/middleware/lookup-tokens.js
+++ b/src/receiver/middleware/lookup-tokens.js
@@ -22,7 +22,11 @@ module.exports = (options) => {
       // token for a bot user of the app
       bot_token: req.headers['bb-slackbotaccesstoken'],
       // userID of the bot user of the app
-      bot_user_id: req.headers['bb-slackbotuserid']
+      bot_user_id: req.headers['bb-slackbotuserid'],
+      // additional team meta-data
+      bot_user_name: req.headers['bb-slackbotusername'],
+      team_name: req.headers['bb-slackteamname'],
+      team_domain: req.headers['bb-slackteamdomain']
     })
 
     next()

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -23,6 +23,9 @@ exports.getMockHeaders = function (headers) {
     'bb-slackaccesstoken': 'slackaccesstoken',
     'bb-slackuserid': 'slackuserid',
     'bb-slackbotaccesstoken': 'slackbotaccesstoken',
-    'bb-slackbotuserid': 'slackbotuserid'
+    'bb-slackbotuserid': 'slackbotuserid',
+    'bb-slackbotusername': 'slackbotusername',
+    'bb-slackteamname': 'slackteamname',
+    'bb-slackteamdomain': 'slackteamdomain'
   }, headers || {})
 }

--- a/test/middleware.lookup-token.test.js
+++ b/test/middleware.lookup-token.test.js
@@ -6,7 +6,7 @@ const fixtures = require('./fixtures/')
 const LookupTokens = require('../src/receiver/middleware/lookup-tokens')
 
 test.cb('LookupToken()', t => {
-  t.plan(4)
+  t.plan(7)
 
   let mw = LookupTokens()
   let headers = fixtures.getMockHeaders()
@@ -19,6 +19,9 @@ test.cb('LookupToken()', t => {
     t.is(req.slapp.meta.app_user_id, headers['bb-slackuserid'])
     t.is(req.slapp.meta.bot_token, headers['bb-slackbotaccesstoken'])
     t.is(req.slapp.meta.bot_user_id, headers['bb-slackbotuserid'])
+    t.is(req.slapp.meta.bot_user_name, headers['bb-slackbotusername'])
+    t.is(req.slapp.meta.team_name, headers['bb-slackteamname'])
+    t.is(req.slapp.meta.team_domain, headers['bb-slackteamdomain'])
     t.end()
   })
 })


### PR DESCRIPTION
Adds the following properties to `message.meta`, populated by the corresponding headers.

+ `bot_user_name` => `bb-slackbotusername`
+ `team_name` => `bb-slackteamname`
+ `team_domain` => `bb-slackteamdomain`