### PR TITLE
Rename to Slapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
-# SlackApp
+# Slapp - a library for creating Slack Apps
+(coming soon)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "slackapp",
-  "version": "0.0.10",
+  "name": "slapp",
+  "version": "0.1.0",
   "description": "A module for Slack App integrations",
   "main": "src/index.js",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/BeepBoopHQ/slackapp-js.git"
+    "url": "git+https://github.com/BeepBoopHQ/slapp.git"
   },
   "keywords": [
     "slack",
@@ -24,9 +24,9 @@
   "author": "Mike Brevoort",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/BeepBoopHQ/slackapp-js/issues"
+    "url": "https://github.com/BeepBoopHQ/slapp/issues"
   },
-  "homepage": "https://github.com/BeepBoopHQ/slackapp-js#readme",
+  "homepage": "https://github.com/BeepBoopHQ/slapp#readme",
   "engines": {
     "node": ">=6.0.0"
   },

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -8,12 +8,12 @@ const readmePath = path.join(__dirname, '/../README.md')
 // read source
 const src = [
   {
-    name: 'slackapp',
+    name: 'slapp',
     src: fs.readFileSync(path.join(__dirname, '/../src/index.js'), { encoding: 'utf8' })
   },
   {
-    name: 'SlackApp',
-    src: fs.readFileSync(path.join(__dirname, '/../src/slackapp.js'), { encoding: 'utf8' })
+    name: 'Slapp',
+    src: fs.readFileSync(path.join(__dirname, '/../src/slapp.js'), { encoding: 'utf8' })
   },
   {
     name: 'Message',

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const SlackApp = require('./slackapp')
+const Slapp = require('./slapp')
 
 /**
- * Create a new SlackApp, accepts an options object
+ * Create a new Slapp, accepts an options object
  *
  * Parameters
  * - `opts.app_token`   Slack App token override
@@ -16,9 +16,9 @@ const SlackApp = require('./slackapp')
  * Example
  *
  *
- *     var SlackApp = require('slackapp')
- *     var BeepBoopConvoStore = require('slackapp-convo-beepboop')
- *     var slackapp = SlackApp({
+ *     var Slapp = require('slapp')
+ *     var BeepBoopConvoStore = require('slapp-convo-beepboop')
+ *     var slapp = Slapp({
  *       debug: true,
  *       record: 'out.jsonl',
  *       convo_store: BeepBoopConvoStore({ debug: true }),
@@ -27,13 +27,13 @@ const SlackApp = require('./slackapp')
  *
  *
  * @param {Object} opts
- * @returns {Object} SlackApp
- * @function slackapp
- * @alias slackapp
+ * @returns {Object} Slapp
+ * @function slapp
+ * @alias slapp
  */
 
 function factory (opts) {
-  let app = new SlackApp(opts)
+  let app = new Slapp(opts)
 
   return app.init()
 }

--- a/src/message.js
+++ b/src/message.js
@@ -31,20 +31,20 @@ class Message {
       this.meta.user_id || this.meta.bot_id
     ].join('::')
 
-    this._slackapp = null
+    this._slapp = null
   }
 
   /**
-   * Attach a SlackApp reference
+   * Attach a Slapp reference
    *
    * ##### Parameters
-   * - `slackapp` instance of SlackApp
+   * - `slapp` instance of Slapp
    *
-   * @param {SlackApp} slackapp
+   * @param {Slapp} slapp
    * @api private
    */
-  attachSlackApp (slackapp) {
-    this._slackapp = slackapp
+  attachSlapp (slapp) {
+    this._slapp = slapp
   }
 
   /**
@@ -63,7 +63,7 @@ class Message {
    * @api private
    */
   attachOverrideRoute (fnKey, state) {
-    let fn = this._slackapp.getRoute(fnKey)
+    let fn = this._slapp.getRoute(fnKey)
 
     // TODO: should we bubble up if a function doesn't exist?
     // It may be that it did exist but a new version was deployed that removed it.
@@ -79,7 +79,7 @@ class Message {
   /**
    * Register the next function to route to in a conversation.
    *
-   * The route should be registered already through `slackapp.route`
+   * The route should be registered already through `slapp.route`
    *
    * ##### Parameters
    * - `fnKey` `string`
@@ -106,7 +106,7 @@ class Message {
 
     let key = this.conversation_id
     let expiration = Date.now() + secondsToExpire * 1000
-    this._slackapp.convoStore.set(key, { fnKey, state, expiration })
+    this._slapp.convoStore.set(key, { fnKey, state, expiration })
     return this
   }
 
@@ -115,7 +115,7 @@ class Message {
    */
 
   cancel () {
-    this._slackapp.convoStore.del(this.conversation_id)
+    this._slapp.convoStore.del(this.conversation_id)
   }
 
   /**

--- a/src/receiver/index.js
+++ b/src/receiver/index.js
@@ -44,9 +44,9 @@ module.exports = class Receiver extends EventEmitter {
    */
   attachToExpress (app, opts) {
     let defaults = {
-      event: '/slackapp/event',
-      command: '/slackapp/command',
-      action: '/slackapp/action'
+      event: '/slack/event',
+      command: '/slack/command',
+      action: '/slack/action'
     }
     let options = opts || defaults
 
@@ -93,10 +93,10 @@ module.exports = class Receiver extends EventEmitter {
   }
 
   emitHandler (req, res) {
-    let message = req.slackapp
+    let message = req.slapp
 
     if (!message) {
-      return res.send('Missing req.slackapp')
+      return res.send('Missing req.slapp')
     }
 
     if (this.debug && this.logfn[message.type]) {

--- a/src/receiver/middleware/lookup-tokens.js
+++ b/src/receiver/middleware/lookup-tokens.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// Enrich `req.slackapp.meta` with tokens and user ids parsed from Beep Boop headers
+// Enrich `req.slapp.meta` with tokens and user ids parsed from Beep Boop headers
 module.exports = (options) => {
   options = options || {}
 
@@ -10,11 +10,11 @@ module.exports = (options) => {
       return res.send(req.headers['bb-error'])
     }
 
-    if (!req.slackapp) {
-      return res.send('Missing req.slackapp')
+    if (!req.slapp) {
+      return res.send('Missing req.slapp')
     }
 
-    req.slackapp.meta = Object.assign(req.slackapp.meta || {}, {
+    req.slapp.meta = Object.assign(req.slapp.meta || {}, {
       // token for the user for the app
       app_token: req.headers['bb-slackaccesstoken'],
       // userID for the user who install ed the app

--- a/src/receiver/middleware/parse-action.js
+++ b/src/receiver/middleware/parse-action.js
@@ -19,7 +19,7 @@ module.exports = () => {
         return res.send('Error parsing payload')
       }
 
-      req.slackapp = {
+      req.slapp = {
         type: 'action',
         body: body,
         meta: {

--- a/src/receiver/middleware/parse-command.js
+++ b/src/receiver/middleware/parse-command.js
@@ -8,7 +8,7 @@ module.exports = () => {
     function parseCommand (req, res, next) {
       let body = req.body
 
-      req.slackapp = {
+      req.slapp = {
         type: 'command',
         body: body,
         meta: {

--- a/src/receiver/middleware/parse-event.js
+++ b/src/receiver/middleware/parse-event.js
@@ -20,7 +20,7 @@ module.exports = () => {
       let body = req.body || {}
       let event = body.event || {}
 
-      req.slackapp = {
+      req.slapp = {
         type: 'event',
         body: body,
         meta: {

--- a/src/receiver/middleware/verify-token.js
+++ b/src/receiver/middleware/verify-token.js
@@ -7,7 +7,7 @@ module.exports = (token) => {
       return next()
     }
 
-    let message = req.slackapp
+    let message = req.slapp
     let verifyToken = message && message.meta && message.meta.verify_token
 
     // test verify token

--- a/src/slapp.js
+++ b/src/slapp.js
@@ -6,13 +6,13 @@ const Receiver = require('./receiver/')
 
 /**
  * A Slack App
- * @class SlackApp
+ * @class Slapp
  * @api private
  */
-class SlackApp {
+class Slapp {
 
   /**
-   * Construct a SlackApp, accepts an options object
+   * Construct a Slapp, accepts an options object
    *
    * ##### Parameters
    * - `opts.verify_token` Slack Veryify token to validate authenticity of requests coming from Slack
@@ -23,7 +23,7 @@ class SlackApp {
    * @api private
    * @constructor
    * @param {Object} opts
-   * @returns {Object} SlackApp
+   * @returns {Object} Slapp
    */
 
   constructor (opts) {
@@ -147,7 +147,7 @@ class SlackApp {
   _handle (msg, done) {
     done = done || (() => {})
     let self = this
-    msg.attachSlackApp(self)
+    msg.attachSlapp(self)
     let idx = 0
 
     let next = () => {
@@ -193,15 +193,15 @@ class SlackApp {
    * Attach HTTP routes to an Express app
    *
    * Routes are:
-   * - POST `/slackapp/event`
-   * - POST `/slackapp/command`
-   * - POST `/slackapp/action`
+   * - POST `/slack/event`
+   * - POST `/slack/command`
+   * - POST `/slack/action`
    *
    * ##### Parameters
    * - `app` instance of Express app
-   * - `opts.event` `boolean|string` - event route (defaults to `/slackapp/event`) [optional]
-   * - `opts.command` `boolean|string` - command route (defaults to `/slackapp/command`) [optional]
-   * - `opts.action` `boolean|string` - action route (defaults to `/slackapp/action`) [optional]
+   * - `opts.event` `boolean|string` - event route (defaults to `/slack/event`) [optional]
+   * - `opts.command` `boolean|string` - command route (defaults to `/slack/command`) [optional]
+   * - `opts.action` `boolean|string` - action route (defaults to `/slack/action`) [optional]
    *
    *
    * ##### Returns
@@ -209,16 +209,16 @@ class SlackApp {
    *
    * ```
    * // would attach all routes w/ default paths
-   * slackapp.attachToExpress(app)
+   * slapp.attachToExpress(app)
    *
-   * slackapp.attachToExpress(app, {
-   *   event: true, // would register event route with default of /slackapp/event
+   * slapp.attachToExpress(app, {
+   *   event: true, // would register event route with default of /slack/event
    *   command: false, // would not register a route for commands
    *   action: '/slack-action' // custom route for actions
    * })
    *
    * // would only attach a route for events w/ default path
-   * slackapp.attachToExpress(app, {
+   * slapp.attachToExpress(app, {
    *   event: true
    * })
    * ````
@@ -589,4 +589,4 @@ class SlackApp {
   }
 }
 
-module.exports = SlackApp
+module.exports = Slapp

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -3,7 +3,7 @@
 exports.getMockReq = function (req) {
   return Object.assign({
     body: {},
-    slackapp: {
+    slapp: {
       meta: {}
     }
   }, req || {})

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -21,7 +21,7 @@ test('Message() w/ user_id', t => {
   t.is(msg.type, type)
   t.deepEqual(msg.body, body)
   t.deepEqual(msg.meta, meta)
-  t.is(msg._slackapp, null)
+  t.is(msg._slapp, null)
   t.is(msg.conversation_id, 'team_id::channel_id::user_id')
 })
 
@@ -40,7 +40,7 @@ test('Message() w/o user_id', t => {
   t.is(msg.type, type)
   t.deepEqual(msg.body, body)
   t.deepEqual(msg.meta, meta)
-  t.is(msg._slackapp, null)
+  t.is(msg._slapp, null)
   t.is(msg.conversation_id, 'team_id::channel_id::bot_id')
 })
 
@@ -48,7 +48,7 @@ test('Message() defaults', t => {
   let msg = new Message()
 
   t.is(msg.type, undefined)
-  t.is(msg._slackapp, null)
+  t.is(msg._slapp, null)
   t.deepEqual(msg.body, {})
   t.deepEqual(msg.meta, {})
 })
@@ -71,7 +71,7 @@ test('Message.attachOverrideRoute()', t => {
     return overrideFn
   })
 
-  msg._slackapp = app
+  msg._slapp = app
   msg.attachOverrideRoute('key', state)
   msg.override(msg)
 
@@ -100,7 +100,7 @@ test('Message.route()', t => {
     t.true(data.expiration > Date.now())
   })
 
-  msg._slackapp = app
+  msg._slapp = app
   msg.route(fnKey, state, 60)
   t.true(setStub.calledOnce)
 })
@@ -124,7 +124,7 @@ test('Message.route() defaults', t => {
     t.true(data.expiration > Date.now())
   })
 
-  msg._slackapp = app
+  msg._slapp = app
   msg.route(fnKey)
   t.true(setStub.calledOnce)
 })
@@ -143,7 +143,7 @@ test('Message.cancel()', t => {
     t.is(convoId, msg.conversation_id)
   })
 
-  msg._slackapp = app
+  msg._slapp = app
   msg.cancel()
   t.true(delStub.calledOnce)
 })

--- a/test/middleware.lookup-token.test.js
+++ b/test/middleware.lookup-token.test.js
@@ -15,10 +15,10 @@ test.cb('LookupToken()', t => {
   let res = fixtures.getMockRes()
 
   mw(req, res, () => {
-    t.is(req.slackapp.meta.app_token, headers['bb-slackaccesstoken'])
-    t.is(req.slackapp.meta.app_user_id, headers['bb-slackuserid'])
-    t.is(req.slackapp.meta.bot_token, headers['bb-slackbotaccesstoken'])
-    t.is(req.slackapp.meta.bot_user_id, headers['bb-slackbotuserid'])
+    t.is(req.slapp.meta.app_token, headers['bb-slackaccesstoken'])
+    t.is(req.slapp.meta.app_user_id, headers['bb-slackuserid'])
+    t.is(req.slapp.meta.bot_token, headers['bb-slackbotaccesstoken'])
+    t.is(req.slapp.meta.bot_user_id, headers['bb-slackbotuserid'])
     t.end()
   })
 })
@@ -41,14 +41,14 @@ test('LookupToken() error header', t => {
   t.true(sendStub.calledOnce)
 })
 
-test('LookupToken() missing req.slackapp', t => {
+test('LookupToken() missing req.slapp', t => {
   let mw = LookupTokens()
   let headers = fixtures.getMockHeaders()
 
   let req = fixtures.getMockReq({ headers })
   let res = fixtures.getMockRes()
 
-  delete req.slackapp
+  delete req.slapp
 
   let sendStub = sinon.stub(res, 'send')
 

--- a/test/middleware.parse-action.test.js
+++ b/test/middleware.parse-action.test.js
@@ -38,14 +38,14 @@ test.cb('ParseAction() valid payload', t => {
   let req = { body: { payload: JSON.stringify(payload) } }
 
   mw(req, fixtures.getMockRes(), () => {
-    let slackapp = req.slackapp
+    let slapp = req.slapp
 
-    t.is(slackapp.type, 'action')
-    t.deepEqual(slackapp.body, payload)
-    t.is(slackapp.meta.verify_token, payload.token)
-    t.is(slackapp.meta.user_id, payload.user.id)
-    t.is(slackapp.meta.channel_id, payload.channel.id)
-    t.is(slackapp.meta.team_id, payload.team.id)
+    t.is(slapp.type, 'action')
+    t.deepEqual(slapp.body, payload)
+    t.is(slapp.meta.verify_token, payload.token)
+    t.is(slapp.meta.user_id, payload.user.id)
+    t.is(slapp.meta.channel_id, payload.channel.id)
+    t.is(slapp.meta.team_id, payload.team.id)
     t.end()
   })
 })

--- a/test/middleware.parse-command.test.js
+++ b/test/middleware.parse-command.test.js
@@ -13,14 +13,14 @@ test.cb('ParseCommand() no payload', t => {
   let req = { body: {} }
 
   mw(req, {}, () => {
-    let slackapp = req.slackapp
+    let slapp = req.slapp
 
-    t.is(slackapp.type, 'command')
-    t.deepEqual(slackapp.body, req.body)
-    t.is(slackapp.meta.verify_token, undefined)
-    t.is(slackapp.meta.user_id, undefined)
-    t.is(slackapp.meta.channel_id, undefined)
-    t.is(slackapp.meta.team_id, undefined)
+    t.is(slapp.type, 'command')
+    t.deepEqual(slapp.body, req.body)
+    t.is(slapp.meta.verify_token, undefined)
+    t.is(slapp.meta.user_id, undefined)
+    t.is(slapp.meta.channel_id, undefined)
+    t.is(slapp.meta.team_id, undefined)
     t.end()
   })
 })
@@ -31,14 +31,14 @@ test.cb('ParseCommand() with payload', t => {
   let req = { body: payload }
 
   mw(req, {}, () => {
-    let slackapp = req.slackapp
+    let slapp = req.slapp
 
-    t.is(slackapp.type, 'command')
-    t.deepEqual(slackapp.body, req.body)
-    t.is(slackapp.meta.verify_token, payload.token)
-    t.is(slackapp.meta.user_id, payload.user_id)
-    t.is(slackapp.meta.channel_id, payload.channel_id)
-    t.is(slackapp.meta.team_id, payload.team_id)
+    t.is(slapp.type, 'command')
+    t.deepEqual(slapp.body, req.body)
+    t.is(slapp.meta.verify_token, payload.token)
+    t.is(slapp.meta.user_id, payload.user_id)
+    t.is(slapp.meta.channel_id, payload.channel_id)
+    t.is(slapp.meta.team_id, payload.team_id)
     t.end()
   })
 })

--- a/test/middleware.parse-event.test.js
+++ b/test/middleware.parse-event.test.js
@@ -15,15 +15,15 @@ test.cb('ParseEvent() no payload', t => {
   let req = { body: {} }
 
   mw(req, {}, () => {
-    let slackapp = req.slackapp
+    let slapp = req.slapp
 
-    t.is(slackapp.type, 'event')
-    t.deepEqual(slackapp.body, req.body)
-    t.is(slackapp.meta.verify_token, undefined)
-    t.is(slackapp.meta.user_id, undefined)
-    t.is(slackapp.meta.bot_id, undefined)
-    t.is(slackapp.meta.channel_id, undefined)
-    t.is(slackapp.meta.team_id, undefined)
+    t.is(slapp.type, 'event')
+    t.deepEqual(slapp.body, req.body)
+    t.is(slapp.meta.verify_token, undefined)
+    t.is(slapp.meta.user_id, undefined)
+    t.is(slapp.meta.bot_id, undefined)
+    t.is(slapp.meta.channel_id, undefined)
+    t.is(slapp.meta.team_id, undefined)
     t.end()
   })
 })
@@ -34,15 +34,15 @@ test.cb('ParseEvent() with payload', t => {
   let req = { body: payload }
 
   mw(req, {}, () => {
-    let slackapp = req.slackapp
+    let slapp = req.slapp
 
-    t.is(slackapp.type, 'event')
-    t.deepEqual(slackapp.body, req.body)
-    t.is(slackapp.meta.verify_token, payload.token)
-    t.is(slackapp.meta.user_id, payload.event.user)
-    t.is(slackapp.meta.bot_id, payload.event.bot_id)
-    t.is(slackapp.meta.channel_id, payload.event.channel)
-    t.is(slackapp.meta.team_id, payload.team_id)
+    t.is(slapp.type, 'event')
+    t.deepEqual(slapp.body, req.body)
+    t.is(slapp.meta.verify_token, payload.token)
+    t.is(slapp.meta.user_id, payload.event.user)
+    t.is(slapp.meta.bot_id, payload.event.bot_id)
+    t.is(slapp.meta.channel_id, payload.event.channel)
+    t.is(slapp.meta.team_id, payload.team_id)
     t.end()
   })
 })

--- a/test/middleware.verify-token.test.js
+++ b/test/middleware.verify-token.test.js
@@ -30,7 +30,7 @@ test.cb('VerifyToken() token option matching verify_token', t => {
   let token = 'beepboop'
   let mw = VerifyToken(token)
   let req = fixtures.getMockReq({
-    slackapp: {
+    slapp: {
       meta: {
         verify_token: token
       }
@@ -48,7 +48,7 @@ test('VerifyToken() token option matching verify_token', t => {
   let token = 'beepboop'
   let mw = VerifyToken(token)
   let req = fixtures.getMockReq({
-    slackapp: {
+    slapp: {
       meta: {
         verify_token: 'derp'
       }

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -34,9 +34,9 @@ test('Receiver.attachToExpress() defaults', t => {
   receiver.attachToExpress(app)
 
   t.true(appStub.calledThrice)
-  t.true(appStub.calledWith('/slackapp/event'))
-  t.true(appStub.calledWith('/slackapp/command'))
-  t.true(appStub.calledWith('/slackapp/action'))
+  t.true(appStub.calledWith('/slack/event'))
+  t.true(appStub.calledWith('/slack/command'))
+  t.true(appStub.calledWith('/slack/action'))
 })
 
 test('Receiver.attachToExpress() true, false, string', t => {
@@ -55,18 +55,18 @@ test('Receiver.attachToExpress() true, false, string', t => {
   })
 
   t.true(appStub.calledTwice)
-  t.true(appStub.calledWith('/slackapp/event'))
+  t.true(appStub.calledWith('/slack/event'))
   t.true(appStub.calledWith(actionRoute))
 })
 
-test('Receiver.emitHandler() no req.slackapp', t => {
+test('Receiver.emitHandler() no req.slapp', t => {
   let receiver = new Receiver()
 
   let res = fixtures.getMockRes()
   let sendStub = sinon.stub(res, 'send')
 
   receiver.emitHandler({}, res, () => t.fail())
-  t.true(sendStub.calledWith('Missing req.slackapp'))
+  t.true(sendStub.calledWith('Missing req.slapp'))
 })
 
 test('Receiver.emitHandler() w/ debug', t => {
@@ -80,7 +80,7 @@ test('Receiver.emitHandler() w/ debug', t => {
   let emitStub = sinon.stub(receiver, 'emit')
   let sendStub = sinon.stub(res, 'send')
 
-  receiver.emitHandler({ slackapp: msg }, res, () => t.fail())
+  receiver.emitHandler({ slapp: msg }, res, () => t.fail())
 
   t.true(logStub.calledOnce)
   t.deepEqual(logStub.getCall(0).args[0], msg.body)
@@ -97,7 +97,7 @@ test('Receiver.emitHandler() w/o debug', t => {
   let emitStub = sinon.stub(receiver, 'emit')
   let sendStub = sinon.stub(res, 'send')
 
-  receiver.emitHandler({ slackapp: msg }, res, () => t.fail())
+  receiver.emitHandler({ slapp: msg }, res, () => t.fail())
 
   t.false(logStub.calledOnce)
   t.true(emitStub.calledOnce)

--- a/test/slackapp.test.js
+++ b/test/slackapp.test.js
@@ -2,17 +2,17 @@
 
 const test = require('ava').test
 const sinon = require('sinon')
-const SlackApp = require('../src/slackapp')
+const Slapp = require('../src/slapp')
 const Message = require('../src/message')
 
-test('SlackApp()', t => {
+test('Slapp()', t => {
   let options = {
     debug: true,
     convo_store: () => {},
     error: () => {}
   }
 
-  let app = new SlackApp(options)
+  let app = new Slapp(options)
 
   t.is(app.app_token, options.app_token)
   t.is(app.app_user_id, options.app_user_id)
@@ -29,7 +29,7 @@ test('SlackApp()', t => {
 
 test('Slackapp.use()', t => {
   let mw = () => {}
-  let app = new SlackApp()
+  let app = new Slapp()
 
   t.is(app._middleware.length, 0)
 
@@ -39,16 +39,16 @@ test('Slackapp.use()', t => {
   t.deepEqual(app._middleware, [mw])
 })
 
-test('SlackApp() convo_store string', t => {
-  let app = new SlackApp({
+test('Slapp() convo_store string', t => {
+  let app = new Slapp({
     convo_store: 'memory'
   })
 
   t.is(typeof app.convoStore, 'object')
 })
 
-test('SlackApp.init()', t => {
-  let app = new SlackApp()
+test('Slapp.init()', t => {
+  let app = new Slapp()
 
   app.init()
 
@@ -56,7 +56,7 @@ test('SlackApp.init()', t => {
 })
 
 test('Slackapp.attachToExpress()', t => {
-  let app = new SlackApp()
+  let app = new Slapp()
   let stub = sinon.stub(app.receiver, 'attachToExpress')
 
   app.attachToExpress({})
@@ -64,8 +64,8 @@ test('Slackapp.attachToExpress()', t => {
   t.true(stub.calledOnce)
 })
 
-test('SlackApp.route()', t => {
-  let app = new SlackApp()
+test('Slapp.route()', t => {
+  let app = new Slapp()
   let key = 'routeKey'
   let fn = () => {}
 
@@ -74,8 +74,8 @@ test('SlackApp.route()', t => {
   t.deepEqual(app._registry[key], fn)
 })
 
-test('SlackApp.getRoute()', t => {
-  let app = new SlackApp()
+test('Slapp.getRoute()', t => {
+  let app = new Slapp()
   let key = 'routeKey'
   let fn = () => {}
 
@@ -84,8 +84,8 @@ test('SlackApp.getRoute()', t => {
   t.deepEqual(app.getRoute(key), fn)
 })
 
-test('SlackApp.match()', t => {
-  let app = new SlackApp()
+test('Slapp.match()', t => {
+  let app = new Slapp()
   let fn = () => {}
 
   t.is(app._matchers.length, 0)
@@ -96,15 +96,15 @@ test('SlackApp.match()', t => {
   t.deepEqual(app._matchers, [fn])
 })
 
-test.cb('SlackApp._handle() 1 mw, no override, no matchers', t => {
+test.cb('Slapp._handle() 1 mw, no override, no matchers', t => {
   t.plan(4)
 
-  let app = new SlackApp()
+  let app = new Slapp()
   let message = {
     override: false,
-    attachSlackApp: () => {}
+    attachSlapp: () => {}
   }
-  let attachSlackAppStub = sinon.stub(message, 'attachSlackApp')
+  let attachSlappStub = sinon.stub(message, 'attachSlapp')
 
   app.use((msg, next) => {
     t.deepEqual(msg, message)
@@ -113,35 +113,35 @@ test.cb('SlackApp._handle() 1 mw, no override, no matchers', t => {
   })
 
   app._handle(message, (err, handled) => {
-    t.true(attachSlackAppStub.calledOnce)
+    t.true(attachSlappStub.calledOnce)
     t.is(err, null)
     t.false(handled)
     t.end()
   })
 })
 
-test('SlackApp._handle() no callback provided', t => {
-  let app = new SlackApp()
+test('Slapp._handle() no callback provided', t => {
+  let app = new Slapp()
   let message = {
     override: false,
-    attachSlackApp: () => {}
+    attachSlapp: () => {}
   }
-  let attachSlackAppStub = sinon.stub(message, 'attachSlackApp')
+  let attachSlappStub = sinon.stub(message, 'attachSlapp')
 
   app._handle(message)
 
-  t.true(attachSlackAppStub.calledOnce)
+  t.true(attachSlappStub.calledOnce)
 })
 
-test.cb('SlackApp._handle() 1 mw, no override, 1 matchers', t => {
+test.cb('Slapp._handle() 1 mw, no override, 1 matchers', t => {
   t.plan(4)
 
-  let app = new SlackApp()
+  let app = new Slapp()
   let message = {
     override: false,
-    attachSlackApp: () => {}
+    attachSlapp: () => {}
   }
-  let attachSlackAppStub = sinon.stub(message, 'attachSlackApp')
+  let attachSlappStub = sinon.stub(message, 'attachSlapp')
 
   app
     .use((msg, next) => {
@@ -154,29 +154,29 @@ test.cb('SlackApp._handle() 1 mw, no override, 1 matchers', t => {
     })
 
   app._handle(message, (err, handled) => {
-    t.true(attachSlackAppStub.calledOnce)
+    t.true(attachSlappStub.calledOnce)
     t.is(err, null)
     t.true(handled)
     t.end()
   })
 })
 
-test.cb('SlackApp._handle() no mw, with override, no matchers', t => {
+test.cb('Slapp._handle() no mw, with override, no matchers', t => {
   t.plan(5)
 
-  let app = new SlackApp()
+  let app = new Slapp()
   let message = {
     override: (msg) => {
       t.deepEqual(msg, message)
     },
     conversation_id: 'asdf',
-    attachSlackApp: () => {}
+    attachSlapp: () => {}
   }
-  let attachSlackAppStub = sinon.stub(message, 'attachSlackApp')
+  let attachSlappStub = sinon.stub(message, 'attachSlapp')
   let delSpy = sinon.spy(app.convoStore, 'del')
 
   app._handle(message, (err, handled) => {
-    t.true(attachSlackAppStub.calledOnce)
+    t.true(attachSlappStub.calledOnce)
     t.is(err, null)
     t.true(handled)
     t.true(delSpy.calledWith(message.conversation_id))
@@ -185,26 +185,26 @@ test.cb('SlackApp._handle() no mw, with override, no matchers', t => {
   })
 })
 
-test.cb('SlackApp._handle() with override and del error', t => {
+test.cb('Slapp._handle() with override and del error', t => {
   t.plan(6)
 
-  let app = new SlackApp()
+  let app = new Slapp()
   let message = {
     onError: () => {},
     override: (msg) => {
       t.deepEqual(msg, message)
     },
     conversation_id: 'asdf',
-    attachSlackApp: () => {}
+    attachSlapp: () => {}
   }
-  let attachSlackAppStub = sinon.stub(message, 'attachSlackApp')
+  let attachSlappStub = sinon.stub(message, 'attachSlapp')
   let onErrorSpy = sinon.stub(app, 'onError')
   let delStub = sinon.stub(app.convoStore, 'del', (id, cb) => {
     cb(new Error('kaboom'))
   })
 
   app._handle(message, (err, handled) => {
-    t.true(attachSlackAppStub.calledOnce)
+    t.true(attachSlappStub.calledOnce)
     t.is(err.message, 'kaboom')
     t.true(handled)
     t.true(delStub.calledWith(message.conversation_id))
@@ -214,12 +214,12 @@ test.cb('SlackApp._handle() with override and del error', t => {
   })
 })
 
-test.cb('SlackApp.command() w/o criteria', t => {
+test.cb('Slapp.command() w/o criteria', t => {
   t.plan(3)
 
-  let app = new SlackApp()
+  let app = new Slapp()
   let message = {
-    attachSlackApp () {},
+    attachSlapp () {},
     type: 'command',
     body: {
       command: 'test'
@@ -237,12 +237,12 @@ test.cb('SlackApp.command() w/o criteria', t => {
     })
 })
 
-test.cb('SlackApp.command() w/ criteria string', t => {
+test.cb('Slapp.command() w/ criteria string', t => {
   t.plan(3)
 
-  let app = new SlackApp()
+  let app = new Slapp()
   let message = {
-    attachSlackApp () {},
+    attachSlapp () {},
     type: 'command',
     body: {
       command: 'test',
@@ -261,12 +261,12 @@ test.cb('SlackApp.command() w/ criteria string', t => {
     })
 })
 
-test.cb('SlackApp.command() w/ criteria regex', t => {
+test.cb('Slapp.command() w/ criteria regex', t => {
   t.plan(3)
 
-  let app = new SlackApp()
+  let app = new Slapp()
   let message = {
-    attachSlackApp () {},
+    attachSlapp () {},
     type: 'command',
     body: {
       command: 'test',
@@ -285,12 +285,12 @@ test.cb('SlackApp.command() w/ criteria regex', t => {
     })
 })
 
-test.cb('SlackApp.command() w/ non-matching string criteria', t => {
+test.cb('Slapp.command() w/ non-matching string criteria', t => {
   t.plan(2)
 
-  let app = new SlackApp()
+  let app = new Slapp()
   let message = {
-    attachSlackApp () {},
+    attachSlapp () {},
     type: 'command',
     body: {
       command: 'test',
@@ -307,12 +307,12 @@ test.cb('SlackApp.command() w/ non-matching string criteria', t => {
     })
 })
 
-test.cb('SlackApp.command() w/ non-matching regex criteria', t => {
+test.cb('Slapp.command() w/ non-matching regex criteria', t => {
   t.plan(2)
 
-  let app = new SlackApp()
+  let app = new Slapp()
   let message = {
-    attachSlackApp () {},
+    attachSlapp () {},
     type: 'command',
     body: {
       command: 'test',
@@ -329,12 +329,12 @@ test.cb('SlackApp.command() w/ non-matching regex criteria', t => {
     })
 })
 
-test.cb('SlackApp.action() w/o criteria', t => {
+test.cb('Slapp.action() w/o criteria', t => {
   t.plan(3)
 
-  let app = new SlackApp()
+  let app = new Slapp()
   let message = {
-    attachSlackApp () {},
+    attachSlapp () {},
     type: 'action',
     body: {
       actions: [
@@ -356,12 +356,12 @@ test.cb('SlackApp.action() w/o criteria', t => {
     })
 })
 
-test.cb('SlackApp.action() w/ criteria string', t => {
+test.cb('Slapp.action() w/ criteria string', t => {
   t.plan(3)
 
-  let app = new SlackApp()
+  let app = new Slapp()
   let message = {
-    attachSlackApp () {},
+    attachSlapp () {},
     type: 'action',
     body: {
       actions: [
@@ -383,12 +383,12 @@ test.cb('SlackApp.action() w/ criteria string', t => {
     })
 })
 
-test.cb('SlackApp.action() w/ non-matching criteria', t => {
+test.cb('Slapp.action() w/ non-matching criteria', t => {
   t.plan(2)
 
-  let app = new SlackApp()
+  let app = new Slapp()
   let message = {
-    attachSlackApp () {},
+    attachSlapp () {},
     type: 'action',
     body: {
       actions: [
@@ -408,10 +408,10 @@ test.cb('SlackApp.action() w/ non-matching criteria', t => {
     })
 })
 
-test.cb('SlackApp.message() w/o filter', t => {
+test.cb('Slapp.message() w/o filter', t => {
   t.plan(3)
 
-  let app = new SlackApp()
+  let app = new Slapp()
   let message = new Message('event', {
     event: {
       type: 'message',
@@ -430,10 +430,10 @@ test.cb('SlackApp.message() w/o filter', t => {
     })
 })
 
-test.cb('SlackApp.message() w/ filter', t => {
+test.cb('Slapp.message() w/ filter', t => {
   t.plan(3)
 
-  let app = new SlackApp()
+  let app = new Slapp()
   let message = new Message('event', {
     event: {
       type: 'message',
@@ -455,10 +455,10 @@ test.cb('SlackApp.message() w/ filter', t => {
     })
 })
 
-test.cb('SlackApp.event() w/ string criteria', t => {
+test.cb('Slapp.event() w/ string criteria', t => {
   t.plan(3)
 
-  let app = new SlackApp()
+  let app = new Slapp()
   let message = new Message('event', {
     event: {
       type: 'message',
@@ -477,10 +477,10 @@ test.cb('SlackApp.event() w/ string criteria', t => {
     })
 })
 
-test.cb('SlackApp.event() w/ regex criteria', t => {
+test.cb('Slapp.event() w/ regex criteria', t => {
   t.plan(3)
 
-  let app = new SlackApp()
+  let app = new Slapp()
   let message = new Message('event', {
     event: {
       type: 'message',
@@ -499,10 +499,10 @@ test.cb('SlackApp.event() w/ regex criteria', t => {
     })
 })
 
-test.cb('SlackApp._handle() w/ init()', t => {
+test.cb('Slapp._handle() w/ init()', t => {
   t.plan(3)
 
-  let app = new SlackApp()
+  let app = new Slapp()
   let message = new Message('event', {
     event: {
       type: 'message',
@@ -522,8 +522,8 @@ test.cb('SlackApp._handle() w/ init()', t => {
     })
 })
 
-test.cb('SlackApp.ignoreBotsMiddleware() with bot message', t => {
-  let app = new SlackApp()
+test.cb('Slapp.ignoreBotsMiddleware() with bot message', t => {
+  let app = new Slapp()
   let mw = app.ignoreBotsMiddleware()
 
   let message = new Message('event', {}, {
@@ -538,8 +538,8 @@ test.cb('SlackApp.ignoreBotsMiddleware() with bot message', t => {
   t.end()
 })
 
-test.cb('SlackApp.ignoreBotsMiddleware() w/o bot message', t => {
-  let app = new SlackApp()
+test.cb('Slapp.ignoreBotsMiddleware() w/o bot message', t => {
+  let app = new Slapp()
   let mw = app.ignoreBotsMiddleware()
 
   let message = new Message('event', {}, {})
@@ -551,10 +551,10 @@ test.cb('SlackApp.ignoreBotsMiddleware() w/o bot message', t => {
   })
 })
 
-test.cb('SlackApp.preprocessConversationMiddleware() w/ conversation', t => {
+test.cb('Slapp.preprocessConversationMiddleware() w/ conversation', t => {
   t.plan(3)
 
-  let app = new SlackApp()
+  let app = new Slapp()
   let mw = app.preprocessConversationMiddleware()
   let message = new Message('event', {}, {})
   message.conversation_id = 'convo_id'
@@ -579,10 +579,10 @@ test.cb('SlackApp.preprocessConversationMiddleware() w/ conversation', t => {
   })
 })
 
-test.cb('SlackApp.preprocessConversationMiddleware() w/o conversation', t => {
+test.cb('Slapp.preprocessConversationMiddleware() w/o conversation', t => {
   t.plan(3)
 
-  let app = new SlackApp()
+  let app = new Slapp()
   let mw = app.preprocessConversationMiddleware()
   let message = new Message('event', {}, {})
   message.conversation_id = 'convo_id'
@@ -601,10 +601,10 @@ test.cb('SlackApp.preprocessConversationMiddleware() w/o conversation', t => {
   })
 })
 
-test.cb('SlackApp.preprocessConversationMiddleware() w/ error', t => {
+test.cb('Slapp.preprocessConversationMiddleware() w/ error', t => {
   t.plan(4)
 
-  let app = new SlackApp()
+  let app = new Slapp()
   let mw = app.preprocessConversationMiddleware()
   let message = new Message('event', {}, {})
   message.conversation_id = 'convo_id'


### PR DESCRIPTION
Big Rename from SlackApp to Slapp

Changed default routes to `/slack/...`