### PR TITLE
Logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   },
   "dependencies": {
     "body-parser": "^1.15.2",
+    "chalk": "^1.1.3",
+    "deap": "^1.0.0",
     "request": "^2.73.0",
     "slack": "^7.5.7"
   },

--- a/src/conversation_store/index.js
+++ b/src/conversation_store/index.js
@@ -14,5 +14,9 @@ module.exports = (opts) => {
     storage = new MemoryStore()
   }
 
+  if (!storage) {
+    throw new Error('Could not define storage for type ' + opts.type)
+  }
+
   return storage
 }

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,9 @@ const Slapp = require('./slapp')
  * - `opts.verify_token` Slack Veryify token to validate authenticity of requests coming from Slack
  * - `opts.convo_store` Implementation of ConversationStore, defaults to memory
  * - `opts.tokens_lookup` `Function (req, res, next)` HTTP Middleware function to enrich incoming request with tokens
- * - `opts.error`       Error handler function `(error) => {}`
+ * - `opts.error` Error handler function `(error) => {}`
+ * - `opts.debug` - defaults to `false` - if `true` default logger will be enabled
+ * - `opts.logger` - defaults to null - Should be an object w/ a `debug` and `error` function
  *
  * Example
  *

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const Slapp = require('./slapp')
  * - `opts.convo_store` Implementation of ConversationStore, defaults to memory
  * - `opts.tokens_lookup` `Function (req, res, next)` HTTP Middleware function to enrich incoming request with tokens
  * - `opts.log` defaults to `true`, `false` to disable logging
- * - `opts.colors` defaults to `true`, `false` to disable colors in logging
+ * - `opts.colors` defaults to `process.stdout.isTTY`, `true` to enable colors in logging
  *
  * Example
  *

--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,8 @@ const Slapp = require('./slapp')
  * - `opts.verify_token` Slack Veryify token to validate authenticity of requests coming from Slack
  * - `opts.convo_store` Implementation of ConversationStore, defaults to memory
  * - `opts.tokens_lookup` `Function (req, res, next)` HTTP Middleware function to enrich incoming request with tokens
- * - `opts.error` Error handler function `(error) => {}`
- * - `opts.debug` - defaults to `false` - if `true` default logger will be enabled
- * - `opts.logger` - defaults to null - Should be an object w/ a `debug` and `error` function
+ * - `opts.log` defaults to `true`, `false` to disable logging
+ * - `opts.colors` defaults to `true`, `false` to disable colors in logging
  *
  * Example
  *
@@ -19,10 +18,8 @@ const Slapp = require('./slapp')
  *     var Slapp = require('slapp')
  *     var BeepBoopConvoStore = require('slapp-convo-beepboop')
  *     var slapp = Slapp({
- *       debug: true,
  *       record: 'out.jsonl',
- *       convo_store: BeepBoopConvoStore({ debug: true }),
- *       error: (err) => { console.error('Error: ', err) }
+ *       convo_store: BeepBoopConvoStore({ debug: true })
  *     })
  *
  *

--- a/src/index.js
+++ b/src/index.js
@@ -6,11 +6,9 @@ const Slapp = require('./slapp')
  * Create a new Slapp, accepts an options object
  *
  * Parameters
- * - `opts.app_token`   Slack App token override
- * - `opts.app_user_id` Slack App User ID (who installed the app)
- * - `opts.bot_token`   Slack App Bot token
- * - `opts.bot_user_id` Slack App Bot ID
+ * - `opts.verify_token` Slack Veryify token to validate authenticity of requests coming from Slack
  * - `opts.convo_store` Implementation of ConversationStore, defaults to memory
+ * - `opts.tokens_lookup` `Function (req, res, next)` HTTP Middleware function to enrich incoming request with tokens
  * - `opts.error`       Error handler function `(error) => {}`
  *
  * Example

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,23 @@
+
+// Keeping it simple. The default logger only logs (at any level)
+// if debug is true. In error cases, where you might assume we should always log
+// the errors are emitted so the consuming code has an opportunity to handle.
+module.exports = function Logger (debug) {
+  return {
+    debug: function () {
+      if (debug) {
+        var args = Array.prototype.slice.call(arguments)
+        args[0] = 'debug: ' + args[0]
+        console.log.apply(console, args)
+      }
+    },
+
+    error: function () {
+      if (debug) {
+        var args = Array.prototype.slice.call(arguments)
+        args[0] = 'error: ' + args[0]
+        console.log.apply(console, args)
+      }
+    }
+  }
+}

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,23 +1,11 @@
+const chalk = require('chalk')
 
-// Keeping it simple. The default logger only logs (at any level)
-// if debug is true. In error cases, where you might assume we should always log
-// the errors are emitted so the consuming code has an opportunity to handle.
-module.exports = function Logger (debug) {
-  return {
-    debug: function () {
-      if (debug) {
-        var args = Array.prototype.slice.call(arguments)
-        args[0] = 'debug: ' + args[0]
-        console.log.apply(console, args)
-      }
-    },
-
-    error: function () {
-      if (debug) {
-        var args = Array.prototype.slice.call(arguments)
-        args[0] = 'error: ' + args[0]
-        console.log.apply(console, args)
-      }
-    }
-  }
+module.exports = (app) => {
+  app
+    .on('info', info => {
+      console.log([chalk.green('slapp:info'), info].join(' '))
+    })
+    .on('error', err => {
+      console.log([chalk.red('slapp:error'), err.message || err].join(' '))
+    })
 }

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,11 +1,20 @@
+'use strict'
+
 const chalk = require('chalk')
 
-module.exports = (app) => {
+module.exports = (app, opts) => {
+  opts = opts || {}
+  let colors = opts.colors
+
+  function c (val, color) {
+    return colors ? chalk[color](val) : val
+  }
+
   app
     .on('info', info => {
-      console.log([chalk.green('slapp:info'), info].join(' '))
+      console.log([c('slapp:info', 'green'), info].join(' '))
     })
     .on('error', err => {
-      console.log([chalk.red('slapp:error'), err.message || err].join(' '))
+      console.log([c('slapp:error', 'red'), (err && err.message) || err].join(' '))
     })
 }

--- a/src/message-formatter.js
+++ b/src/message-formatter.js
@@ -1,0 +1,100 @@
+'use strict'
+
+const chalk = require('chalk')
+
+module.exports = (opts) => {
+  opts = opts || {}
+  const withColors = opts.colors !== false
+
+  var formatters = {
+
+    event (msg) {
+      let event = msg.body.event || {}
+      let msgType = event.type + (event.subtype ? `.${event.subtype}` : '')
+      let text = event.text || event.reaction || ''
+      let channelId = event.channel || (event.item && event.item.channel)
+
+      let output = [
+        `${type(msg.type)}`,
+        `${team(msg.body.team_id)}`,
+        `${channel(channelId)}`,
+        event.bot_id ? `${bot(event.bot_id)}` : `${user(event.user)}`,
+        `${c(msgType, 'yellow')}`,
+        `${text}`
+      ].join(' ')
+
+      if ((event.attachments || []).length > 0) {
+        output += `${event.attachments.length} attachments`
+      }
+
+      return output
+    },
+
+    action (msg) {
+      let actions = (msg.body.actions || []).map(action => {
+        return `${action.name}=${action.value}`
+      })
+
+      return [
+        `${type(msg.type)}`,
+        `${team(msg.body.team.id)}`,
+        `${channel(msg.body.channel.id)}`,
+        `${user(msg.body.user.id)}`,
+        `${actions.join(',')}`
+      ].join(' ')
+    },
+
+    command (msg) {
+      return [
+        `${type(msg.type)}`,
+        `${team(msg.body.team_id)}`,
+        `${channel(msg.body.channel_id)}`,
+        `${user(msg.body.user_id)}`,
+        `${msg.body.command}`,
+        `${msg.body.text}`
+      ].join(' ')
+    }
+
+  }
+
+  function c (val, color) {
+    return withColors ? chalk[color](val) : val
+  }
+
+  function type (val) {
+    val = {
+      'action': 'act',
+      'event': 'evt',
+      'command': 'cmd'
+    }[val]
+
+    return c(`[${val}]`, 'gray')
+  }
+
+  function team (val) {
+    return c(`tm=${val}`, 'red')
+  }
+
+  function channel (val) {
+    return c(`ch=${val}`, 'magenta')
+  }
+
+  function user (val) {
+    return c(`usr=${val}`, 'cyan')
+  }
+
+  function bot (val) {
+    return c(`bot=${val}`, 'cyan')
+  }
+
+  return function formatMessage (msg) {
+    if (!msg) {
+      return null
+    }
+    if (!formatters[msg.type]) {
+      return `Unknown type: ${type(msg.type)}`
+    }
+
+    return formatters[msg.type](msg)
+  }
+}

--- a/src/message-formatter.js
+++ b/src/message-formatter.js
@@ -34,12 +34,15 @@ module.exports = (opts) => {
       let actions = (msg.body.actions || []).map(action => {
         return `${action.name}=${action.value}`
       })
+      let teamId = msg.body.team && msg.body.team.id || 'UNKNOWN'
+      let channelId = msg.body.channel && msg.body.channel.id || 'UNKNOWN'
+      let userId = msg.body.user && msg.body.user.id || 'UNKNOWN'
 
       return [
         `${type(msg.type)}`,
-        `${team(msg.body.team.id)}`,
-        `${channel(msg.body.channel.id)}`,
-        `${user(msg.body.user.id)}`,
+        `${team(teamId)}`,
+        `${channel(channelId)}`,
+        `${user(userId)}`,
         `${actions.join(',')}`
       ].join(' ')
     },
@@ -66,7 +69,7 @@ module.exports = (opts) => {
       'action': 'act',
       'event': 'evt',
       'command': 'cmd'
-    }[val]
+    }[val] || val
 
     return c(`[${val}]`, 'gray')
   }

--- a/src/receiver/index.js
+++ b/src/receiver/index.js
@@ -112,7 +112,6 @@ module.exports = class Receiver extends EventEmitter {
     res.send()
   }
 
-  // TODO: extract log fns into an overridable logger
   logEvent (evt) {
     if (!evt) return this.log.debug('Event: UNKNOWN')
     if (!evt.event) return this.log.debug('Event: Missing:', evt)

--- a/src/receiver/index.js
+++ b/src/receiver/index.js
@@ -116,7 +116,7 @@ module.exports = class Receiver extends EventEmitter {
     if (!evt) return this.log.debug('Event: UNKNOWN')
     if (!evt.event) return this.log.debug('Event: Missing:', evt)
 
-    let out = `${evt.event.user} -> ${evt.event.type}`
+    let out = `${evt.event.user || '-'} -> ${evt.event.type}`
     switch (evt.event.type) {
       case 'reaction_added':
         out += ` : ${evt.event.item.type} [${evt.event.item.channel}] : ${evt.event.reaction}`

--- a/src/receiver/middleware/lookup-tokens.js
+++ b/src/receiver/middleware/lookup-tokens.js
@@ -1,15 +1,10 @@
 'use strict'
 
 // Enrich `req.slapp.meta` with tokens and user ids parsed from Beep Boop headers
-module.exports = (options) => {
-  options = options || {}
-  let log = options.logger
-
+module.exports = () => {
   return function tokenMiddleware (req, res, next) {
     if (req.headers['bb-error']) {
-      if (log && log.error) {
-        log.error('Event: Error: ' + req.headers['bb-error'])
-      }
+      console.log('Event: Error: ' + req.headers['bb-error'])
       return res.send(req.headers['bb-error'])
     }
 

--- a/src/receiver/middleware/lookup-tokens.js
+++ b/src/receiver/middleware/lookup-tokens.js
@@ -4,7 +4,7 @@
 module.exports = () => {
   return function tokenMiddleware (req, res, next) {
     if (req.headers['bb-error']) {
-      console.log('Event: Error: ' + req.headers['bb-error'])
+      console.error('Event: Error: ' + req.headers['bb-error'])
       return res.send(req.headers['bb-error'])
     }
 

--- a/src/receiver/middleware/lookup-tokens.js
+++ b/src/receiver/middleware/lookup-tokens.js
@@ -3,10 +3,13 @@
 // Enrich `req.slapp.meta` with tokens and user ids parsed from Beep Boop headers
 module.exports = (options) => {
   options = options || {}
+  let log = options.logger
 
   return function tokenMiddleware (req, res, next) {
     if (req.headers['bb-error']) {
-      console.error('Event: Error: ' + req.headers['bb-error'])
+      if (log && log.error) {
+        log.error('Event: Error: ' + req.headers['bb-error'])
+      }
       return res.send(req.headers['bb-error'])
     }
 

--- a/src/slapp.js
+++ b/src/slapp.js
@@ -47,6 +47,7 @@ class Slapp extends EventEmitter {
 
     this.verify_token = opts.verify_token
     this.log = opts.log
+    this.colors = opts.colors
     this.formatter = Formatter({
       colors: opts.colors
     })
@@ -65,7 +66,7 @@ class Slapp extends EventEmitter {
   }
 
   /**
-   * Initialize app w/ default middleware and receiver listener
+   * Initialize app w/ logger, default middleware and receiver listener
    *
    *
    * ##### Returns
@@ -76,7 +77,9 @@ class Slapp extends EventEmitter {
   init () {
     // attach default logging if enabled
     if (this.log) {
-      logger(this)
+      logger(this, {
+        colors: this.colors
+      })
     }
     // call `handle` for each new request
     this.receiver.on('message', this._handle.bind(this))

--- a/src/slapp.js
+++ b/src/slapp.js
@@ -20,7 +20,9 @@ class Slapp extends EventEmitter {
    * - `opts.verify_token` Slack Veryify token to validate authenticity of requests coming from Slack
    * - `opts.convo_store` Implementation of ConversationStore, defaults to memory
    * - `opts.tokens_lookup` `Function (req, res, next)` HTTP Middleware function to enrich incoming request with tokens
-   * - `opts.error`       Error handler function `(error) => {}`
+   * - `opts.error` Error handler function `(error) => {}`
+   * - `opts.debug` - defaults to `false` - if `true` default logger will be enabled
+   * - `opts.logger` - defaults to null - Should be an object w/ a `debug` and `error` function
    *
    * @api private
    * @constructor

--- a/test/fixtures/messages/action.json
+++ b/test/fixtures/messages/action.json
@@ -1,15 +1,31 @@
 {
-  "type": "event",
+  "type": "action",
   "body": {
-    "token": "UXXXXXXXXXXXXXXX",
-    "team_id": "TXXXXXXXX",
-    "api_app_id": "AXXXXXXXX",
-    "event": {
-      "type": "message",
-      "user": "UXXXXXXXX",
-      "text": "help",
-      "ts": "1469983827.000002",
-      "channel": "DXXXXXXXX",
+    "actions": [{
+      "name": "answer",
+      "value": "in"
+    }],
+    "callback_id": "in_or_out_callback",
+    "team": {
+      "id": "TXXXXXXXX",
+      "domain": "norrischuck"
+    },
+    "channel": {
+      "id": "DXXXXXXXX",
+      "name": "directmessage"
+    },
+    "user": {
+      "id": "UXXXXXXXX",
+      "name": "brad"
+    },
+    "action_ts": "1470062914.569030",
+    "message_ts": "1470062905.000002",
+    "attachment_id": "1",
+    "token": "XXXXXXXXXXXXXXX",
+    "original_message": {
+      "text": "",
+      "username": "In or Out",
+      "bot_id": "B1VL5FJKD",
       "attachments": [{
         "callback_id": "in_or_out_callback",
         "text": "In or Out?",
@@ -44,22 +60,23 @@
         }],
         "fallback": "NO FALLBACK DEFINED"
       }],
-      "event_ts": "1469983827.000002"
+      "type": "message",
+      "subtype": "bot_message",
+      "ts": "1470062905.000002"
     },
-    "type": "event_callback",
-    "authed_users": ["UXXXXXXXX"]
+    "response_url": "https://hooks.slack.com/actions/TXXXXXXXX/65070116791/jenjzX5R5MpDHXrCPPZIKulu"
   },
   "meta": {
-    "verify_token": "UXXXXXXXXXXXXXXX",
+    "verify_token": "XXXXXXXXXXXXXXX",
     "user_id": "UXXXXXXXX",
     "channel_id": "DXXXXXXXX",
     "team_id": "TXXXXXXXX",
-    "app_token": "xoxp-xxxxxxxxxxx-xxxxxxxxxxx-xxxxxxxxxxx-xxxxxxxxxxx",
+    "app_token": "xoxp-XXXXXXXXXXX-XXXXXXXXXXX-XXXXXXXXXXX-XXXXXXXXXXX",
     "app_user_id": "UXXXXXXXX",
-    "bot_token": "xoxb-xxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx",
+    "bot_token": "xoxb-XXXXXXXXXXX-XXXXXXXXXXXXX",
     "bot_user_id": "UXXXXXXXX"
   },
   "conversation_id": "TXXXXXXXX::DXXXXXXXX::UXXXXXXXX",
   "_slapp": null,
-  "delay": 11678
+  "delay": 19919
 }

--- a/test/fixtures/messages/command.json
+++ b/test/fixtures/messages/command.json
@@ -1,0 +1,28 @@
+{
+  "type": "command",
+  "body": {
+    "token": "UXXXXXXXXXXXXXXX",
+    "team_id": "TXXXXXXXX",
+    "team_domain": "teamdomain",
+    "channel_id": "DXXXXXXXX",
+    "channel_name": "directmessage",
+    "user_id": "UXXXXXXXX",
+    "user_name": "brad",
+    "command": "/joke",
+    "text": "",
+    "response_url": "https://hooks.slack.com/commands/TXXXXXXXX/XXXXXXXXXXX/xxxxxxxxxxxxxxxxxxxxxxxx"
+  },
+  "meta": {
+    "verify_token": "UXXXXXXXXXXXXXXX",
+    "user_id": "UXXXXXXXX",
+    "channel_id": "DXXXXXXXX",
+    "team_id": "TXXXXXXXX",
+    "app_token": "xoxp-xxxxxxxxxxx-xxxxxxxxxxx-xxxxxxxxxxx-xxxxxxxxxxx",
+    "app_user_id": "UXXXXXXXX",
+    "bot_token": "xoxb-xxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx",
+    "bot_user_id": "UXXXXXXXX"
+  },
+  "conversation_id": "TXXXXXXXX::DXXXXXXXX::UXXXXXXXX",
+  "_slapp": null,
+  "delay": 30783
+}

--- a/test/fixtures/messages/event.message.bot_message.json
+++ b/test/fixtures/messages/event.message.bot_message.json
@@ -1,0 +1,32 @@
+{
+  "type": "event",
+  "body": {
+    "token": "UXXXXXXXXXXXXXXX",
+    "team_id": "TXXXXXXXX",
+    "api_app_id": "AXXXXXXXX",
+    "event": {
+      "text": "Q: Why did the tomato turn red?\nA: Because it saw the salad dressing!",
+      "bot_id": "BXXXXXXXX",
+      "type": "message",
+      "subtype": "bot_message",
+      "ts": "1469983849.000004",
+      "channel": "DXXXXXXXX",
+      "event_ts": "1469983849.000004"
+    },
+    "type": "event_callback",
+    "authed_users": ["UXXXXXXXX"]
+  },
+  "meta": {
+    "verify_token": "UXXXXXXXXXXXXXXX",
+    "bot_id": "BXXXXXXXX",
+    "channel_id": "DXXXXXXXX",
+    "team_id": "TXXXXXXXX",
+    "app_token": "xoxb-xxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx",
+    "app_user_id": "UXXXXXXXX",
+    "bot_token": "xoxb-xxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx",
+    "bot_user_id": "UXXXXXXXX"
+  },
+  "conversation_id": "TXXXXXXXX::DXXXXXXXX::BXXXXXXXX",
+  "_slapp": null,
+  "delay": 32315
+}

--- a/test/fixtures/messages/event.message.json
+++ b/test/fixtures/messages/event.message.json
@@ -1,0 +1,31 @@
+{
+  "type": "event",
+  "body": {
+    "token": "UXXXXXXXXXXXXXXX",
+    "team_id": "TXXXXXXXX",
+    "api_app_id": "AXXXXXXXX",
+    "event": {
+      "type": "message",
+      "user": "UXXXXXXXX",
+      "text": "help",
+      "ts": "1469983827.000002",
+      "channel": "DXXXXXXXX",
+      "event_ts": "1469983827.000002"
+    },
+    "type": "event_callback",
+    "authed_users": ["UXXXXXXXX"]
+  },
+  "meta": {
+    "verify_token": "UXXXXXXXXXXXXXXX",
+    "user_id": "UXXXXXXXX",
+    "channel_id": "DXXXXXXXX",
+    "team_id": "TXXXXXXXX",
+    "app_token": "xoxp-xxxxxxxxxxx-xxxxxxxxxxx-xxxxxxxxxxx-xxxxxxxxxxx",
+    "app_user_id": "UXXXXXXXX",
+    "bot_token": "xoxb-xxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx",
+    "bot_user_id": "UXXXXXXXX"
+  },
+  "conversation_id": "TXXXXXXXX::DXXXXXXXX::UXXXXXXXX",
+  "_slapp": null,
+  "delay": 11678
+}

--- a/test/fixtures/messages/event.reaction_added.json
+++ b/test/fixtures/messages/event.reaction_added.json
@@ -1,0 +1,33 @@
+{
+  "type": "event",
+  "body": {
+    "token": "UXXXXXXXXXXXXXXX",
+    "team_id": "TXXXXXXXX",
+    "api_app_id": "AXXXXXXXX",
+    "event": {
+      "type": "reaction_added",
+      "user": "UXXXXXXXX",
+      "item": {
+        "type": "message",
+        "channel": "DXXXXXXXX",
+        "ts": "1469983855.000006"
+      },
+      "reaction": "+1",
+      "event_ts": "1469983859.686541"
+    },
+    "type": "event_callback",
+    "authed_users": ["UXXXXXXXX"]
+  },
+  "meta": {
+    "verify_token": "UXXXXXXXXXXXXXXX",
+    "user_id": "UXXXXXXXX",
+    "team_id": "TXXXXXXXX",
+    "app_token": "xoxp-xxxxxxxxxxx-xxxxxxxxxxx-xxxxxxxxxxx-xxxxxxxxxxx",
+    "app_user_id": "UXXXXXXXX",
+    "bot_token": "xoxb-xxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx",
+    "bot_user_id": "UXXXXXXXX"
+  },
+  "conversation_id": "TXXXXXXXX::::UXXXXXXXX",
+  "_slapp": null,
+  "delay": 42965
+}

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -3,35 +3,45 @@
 const test = require('ava').test
 const sinon = require('sinon')
 const Logger = require('../src/logger')
+const EventEmitter = require('events')
 
-test('Logger() w/ debug', t => {
-  let logger = Logger(true)
+test('Logger()', t => {
+  let app = new EventEmitter()
+
+  Logger(app)
+
+  t.is(app.listenerCount('info'), 1)
+  t.is(app.listenerCount('error'), 1)
+})
+
+test('Logger() info', t => {
+  let app = new EventEmitter()
+
+  Logger(app)
 
   let logStub = sinon.stub(console, 'log')
 
-  logger.debug('one')
-  logger.error('two')
+  app.emit('info')
 
-  t.true(logStub.calledTwice)
-
-  let logArg = logStub.getCall(0).args[0]
-  let errorArg = logStub.getCall(1).args[0]
-
-  t.true(logArg.indexOf('debug:') >= 0)
-  t.true(errorArg.indexOf('error:') >= 0)
+  let info = logStub.getCall(0).args[0]
+  t.true(logStub.calledOnce)
+  t.true(info.indexOf('slapp:info') >= 0)
 
   console.log.restore()
 })
 
-test('Logger() w/o debug', t => {
-  let logger = Logger()
+test('Logger() error', t => {
+  let app = new EventEmitter()
+
+  Logger(app)
 
   let logStub = sinon.stub(console, 'log')
 
-  logger.debug('one')
-  logger.error('two')
+  app.emit('error')
 
-  t.false(logStub.called)
+  let info = logStub.getCall(0).args[0]
+  t.true(logStub.calledOnce)
+  t.true(info.indexOf('slapp:error') >= 0)
 
   console.log.restore()
 })

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const test = require('ava').test
+const sinon = require('sinon')
+const Logger = require('../src/logger')
+
+test('Logger() w/ debug', t => {
+  let logger = Logger(true)
+
+  let logStub = sinon.stub(console, 'log')
+
+  logger.debug('one')
+  logger.error('two')
+
+  t.true(logStub.calledTwice)
+
+  let logArg = logStub.getCall(0).args[0]
+  let errorArg = logStub.getCall(1).args[0]
+
+  t.true(logArg.indexOf('debug:') >= 0)
+  t.true(errorArg.indexOf('error:') >= 0)
+
+  console.log.restore()
+})
+
+test('Logger() w/o debug', t => {
+  let logger = Logger()
+
+  let logStub = sinon.stub(console, 'log')
+
+  logger.debug('one')
+  logger.error('two')
+
+  t.false(logStub.called)
+
+  console.log.restore()
+})

--- a/test/memory.convoStore.test.js
+++ b/test/memory.convoStore.test.js
@@ -1,7 +1,28 @@
 'use strict'
 
 const test = require('ava').test
+const Store = require('../src/conversation_store/')
 const Memory = require('../src/conversation_store/memory')
+
+test('Store() w/ no type', t => {
+  let store = Store()
+
+  t.true(store instanceof Memory)
+})
+
+test('Store() w/ memory type', t => {
+  let store = Store({
+    type: 'memory'
+  })
+
+  t.true(store instanceof Memory)
+})
+
+test('Store() w/ invalid type', t => {
+  t.throws(() => {
+    Store({ type: 'invalid' })
+  })
+})
 
 test.cb('Memory() crud', t => {
   t.plan(5)

--- a/test/message-formatter.test.js
+++ b/test/message-formatter.test.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const test = require('ava').test
+const sinon = require('sinon')
+const Formatter = require('../src/message-formatter')
+
+const eventMsgBotMsg = require('./fixtures/messages/event.message.bot_message')
+
+test('Formatter()', t => {
+  let format = Formatter()
+
+  t.is(typeof format, 'function')
+})
+
+test('Formatter() unknown w/ colors', t => {
+  let format = Formatter()
+  let msg = { type: 'beepboop' }
+
+  let output = format(msg)
+
+  t.is(output, `Unknown type: ${'beepboop'.gray}`)
+})
+
+test('Formatter() unknown w/o colors', t => {
+  let format = Formatter({ colors: false })
+  let msg = { type: 'beepboop' }
+
+  let output = format(msg)
+
+  t.is(output, 'Unknown type: beepboop')
+})
+
+test('Formatter() event message.bot_message', t => {
+  let format = Formatter({ colors: true })
+  let output = format(eventMsgBotMsg)
+
+  console.log(output)
+  t.pass()
+})

--- a/test/message-formatter.test.js
+++ b/test/message-formatter.test.js
@@ -1,10 +1,14 @@
 'use strict'
 
 const test = require('ava').test
-const sinon = require('sinon')
+const chalk = require('chalk')
+// const sinon = require('sinon')
 const Formatter = require('../src/message-formatter')
 
+const eventMsg = require('./fixtures/messages/event.message')
 const eventMsgBotMsg = require('./fixtures/messages/event.message.bot_message')
+const actionMsg = require('./fixtures/messages/action')
+const commandMsg = require('./fixtures/messages/command')
 
 test('Formatter()', t => {
   let format = Formatter()
@@ -17,8 +21,8 @@ test('Formatter() unknown w/ colors', t => {
   let msg = { type: 'beepboop' }
 
   let output = format(msg)
-
-  t.is(output, `Unknown type: ${'beepboop'.gray}`)
+  t.true(output.indexOf('Unknown type') >= 0)
+  t.true(output.indexOf(chalk.gray('[beepboop]')) >= 0)
 })
 
 test('Formatter() unknown w/o colors', t => {
@@ -27,13 +31,41 @@ test('Formatter() unknown w/o colors', t => {
 
   let output = format(msg)
 
-  t.is(output, 'Unknown type: beepboop')
+  t.true(output.indexOf('Unknown type') >= 0)
+  t.true(output.indexOf('beepboop') >= 0)
+})
+
+test('Formatter() event message', t => {
+  let format = Formatter()
+  let output = format(eventMsg)
+
+  t.true(output.indexOf('[evt]') >= 0)
 })
 
 test('Formatter() event message.bot_message', t => {
-  let format = Formatter({ colors: true })
+  let format = Formatter()
   let output = format(eventMsgBotMsg)
 
-  console.log(output)
-  t.pass()
+  t.true(output.indexOf('[evt]') >= 0)
+})
+
+test('Formatter() action', t => {
+  let format = Formatter()
+  let output = format(actionMsg)
+
+  t.true(output.indexOf('[act]') >= 0)
+})
+
+test('Formatter() command', t => {
+  let format = Formatter()
+  let output = format(commandMsg)
+
+  t.true(output.indexOf('[cmd]') >= 0)
+})
+
+test('Formatter() no message', t => {
+  let format = Formatter()
+  let output = format()
+
+  t.is(output, null)
 })

--- a/test/middleware.lookup-token.test.js
+++ b/test/middleware.lookup-token.test.js
@@ -57,7 +57,7 @@ test('LookupToken() error header w/ logger', t => {
   let res = fixtures.getMockRes()
 
   let sendStub = sinon.stub(res, 'send')
-  let logStub = sinon.stub(logger, 'error')
+  let logStub = sinon.stub(console, 'log')
 
   mw(req, res, () => {
     t.fail()
@@ -65,6 +65,7 @@ test('LookupToken() error header w/ logger', t => {
 
   t.true(sendStub.calledOnce)
   t.true(logStub.calledOnce)
+  console.log.restore()
 })
 
 test('LookupToken() missing req.slapp', t => {

--- a/test/middleware.lookup-token.test.js
+++ b/test/middleware.lookup-token.test.js
@@ -44,6 +44,29 @@ test('LookupToken() error header', t => {
   t.true(sendStub.calledOnce)
 })
 
+test('LookupToken() error header w/ logger', t => {
+  let logger = {
+    error: () => {}
+  }
+  let mw = LookupTokens({ logger })
+  let headers = fixtures.getMockHeaders({
+    'bb-error': 'kaboom'
+  })
+
+  let req = fixtures.getMockReq({ headers })
+  let res = fixtures.getMockRes()
+
+  let sendStub = sinon.stub(res, 'send')
+  let logStub = sinon.stub(logger, 'error')
+
+  mw(req, res, () => {
+    t.fail()
+  })
+
+  t.true(sendStub.calledOnce)
+  t.true(logStub.calledOnce)
+})
+
 test('LookupToken() missing req.slapp', t => {
   let mw = LookupTokens()
   let headers = fixtures.getMockHeaders()

--- a/test/middleware.lookup-token.test.js
+++ b/test/middleware.lookup-token.test.js
@@ -57,7 +57,7 @@ test('LookupToken() error header w/ logger', t => {
   let res = fixtures.getMockRes()
 
   let sendStub = sinon.stub(res, 'send')
-  let logStub = sinon.stub(console, 'log')
+  let logStub = sinon.stub(console, 'error')
 
   mw(req, res, () => {
     t.fail()
@@ -65,7 +65,7 @@ test('LookupToken() error header w/ logger', t => {
 
   t.true(sendStub.calledOnce)
   t.true(logStub.calledOnce)
-  console.log.restore()
+  console.error.restore()
 })
 
 test('LookupToken() missing req.slapp', t => {

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -76,14 +76,11 @@ test('Receiver.emitHandler() w/ debug', t => {
   let msg = getMockMessage()
   let res = fixtures.getMockRes()
 
-  let logStub = sinon.stub(receiver.logfn, msg.type)
   let emitStub = sinon.stub(receiver, 'emit')
   let sendStub = sinon.stub(res, 'send')
 
   receiver.emitHandler({ slapp: msg }, res, () => t.fail())
 
-  t.true(logStub.calledOnce)
-  t.deepEqual(logStub.getCall(0).args[0], msg.body)
   t.true(emitStub.calledOnce)
   t.true(sendStub.calledOnce)
 })
@@ -93,172 +90,13 @@ test('Receiver.emitHandler() w/o debug', t => {
   let msg = getMockMessage()
   let res = fixtures.getMockRes()
 
-  let logStub = sinon.stub(receiver.logfn, msg.type)
   let emitStub = sinon.stub(receiver, 'emit')
   let sendStub = sinon.stub(res, 'send')
 
   receiver.emitHandler({ slapp: msg }, res, () => t.fail())
 
-  t.false(logStub.calledOnce)
   t.true(emitStub.calledOnce)
   t.true(sendStub.calledOnce)
-})
-
-test('Receiver.logCommand() no command', t => {
-  let receiver = new Receiver()
-
-  let logStub = sinon.stub(receiver.log, 'debug')
-  receiver.logCommand()
-
-  t.true(logStub.calledWith('Command: UNKNOWN'))
-})
-
-test('Receiver.logCommand() no command prop', t => {
-  let receiver = new Receiver()
-  let cmd = {}
-  let logStub = sinon.stub(receiver.log, 'debug')
-
-  receiver.logCommand(cmd)
-
-  t.true(logStub.calledWith('Command: Missing:', cmd))
-})
-
-test('Receiver.logCommand()', t => {
-  let receiver = new Receiver()
-  let cmd = {
-    command: 'beepboop',
-    user_id: 'user_id',
-    text: 'allthebots'
-  }
-  let logStub = sinon.stub(receiver.log, 'debug')
-
-  receiver.logCommand(cmd)
-
-  let text = logStub.getCall(0).args[0]
-  t.true(text.indexOf(cmd.command) >= 0)
-  t.true(text.indexOf(cmd.user_id) >= 0)
-  t.true(text.indexOf(cmd.text) >= 0)
-})
-
-test('Receiver.logAction() no action', t => {
-  let receiver = new Receiver()
-
-  let logStub = sinon.stub(receiver.log, 'debug')
-  receiver.logAction()
-
-  t.true(logStub.calledWith('Action: UNKNOWN'))
-})
-
-test('Receiver.logAction()', t => {
-  let receiver = new Receiver()
-  let action = {
-    'beep': 'boop'
-  }
-  let logStub = sinon.stub(receiver.log, 'debug')
-
-  receiver.logAction(action)
-
-  t.true(logStub.calledWith('Action:', action))
-})
-
-test('Receiver.logEvent() no event', t => {
-  let receiver = new Receiver()
-
-  let logStub = sinon.stub(receiver.log, 'debug')
-  receiver.logEvent()
-
-  t.true(logStub.calledWith('Event: UNKNOWN'))
-})
-
-test('Receiver.logEvent() no event prop', t => {
-  let receiver = new Receiver()
-  let event = {}
-  let logStub = sinon.stub(receiver.log, 'debug')
-  receiver.logEvent(event)
-
-  t.true(logStub.calledWith('Event: Missing:', event))
-})
-
-test('Receiver.logEvent() unspecified type', t => {
-  let receiver = new Receiver()
-  let event = {
-    event: {
-      type: 'beepboop',
-      user: 'user'
-    }
-  }
-  let logStub = sinon.stub(receiver.log, 'debug')
-  receiver.logEvent(event)
-
-  let text = logStub.getCall(0).args[0]
-  t.true(text.indexOf(event.event.type) >= 0)
-  t.true(text.indexOf(event.event.user) >= 0)
-})
-
-test('Receiver.logEvent() reaction_added', t => {
-  let receiver = new Receiver()
-  let event = {
-    event: {
-      type: 'reaction_added',
-      user: 'user',
-      item: {
-        type: 'item_type',
-        channel: 'item_channel'
-      },
-      reaction: 'reaction'
-    }
-  }
-  let logStub = sinon.stub(receiver.log, 'debug')
-  receiver.logEvent(event)
-
-  let text = logStub.getCall(0).args[0]
-  t.true(text.indexOf(event.event.type) >= 0)
-  t.true(text.indexOf(event.event.user) >= 0)
-  t.true(text.indexOf(event.event.item.type) >= 0)
-  t.true(text.indexOf(event.event.item.channel) >= 0)
-  t.true(text.indexOf(event.event.reaction) >= 0)
-})
-
-test('Receiver.logEvent() message', t => {
-  let receiver = new Receiver()
-  let event = {
-    event: {
-      type: 'message',
-      user: 'user',
-      channel: 'channel',
-      text: 'event text'
-    }
-  }
-  let logStub = sinon.stub(receiver.log, 'debug')
-  receiver.logEvent(event)
-
-  let text = logStub.getCall(0).args[0]
-  t.true(text.indexOf(event.event.type) >= 0)
-  t.true(text.indexOf(event.event.user) >= 0)
-  t.true(text.indexOf(event.event.channel) >= 0)
-  t.true(text.indexOf(event.event.text) >= 0)
-})
-
-test('Receiver.logEvent() message w/ subtype', t => {
-  let receiver = new Receiver()
-  let event = {
-    event: {
-      type: 'message',
-      subtype: 'sub-type',
-      user: 'user',
-      channel: 'channel',
-      text: 'event text'
-    }
-  }
-  let logStub = sinon.stub(receiver.log, 'debug')
-  receiver.logEvent(event)
-
-  let text = logStub.getCall(0).args[0]
-  t.true(text.indexOf(event.event.type) >= 0)
-  t.true(text.indexOf(event.event.subtype) >= 0)
-  t.true(text.indexOf(event.event.user) >= 0)
-  t.true(text.indexOf(event.event.channel) >= 0)
-  t.true(text.indexOf(event.event.text) >= 0)
 })
 
 function getMockMessage () {

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -99,7 +99,7 @@ test('Receiver.emitHandler() w/o debug', t => {
 
   receiver.emitHandler({ slapp: msg }, res, () => t.fail())
 
-  t.true(logStub.calledOnce)
+  t.false(logStub.calledOnce)
   t.true(emitStub.calledOnce)
   t.true(sendStub.calledOnce)
 })

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -99,7 +99,7 @@ test('Receiver.emitHandler() w/o debug', t => {
 
   receiver.emitHandler({ slapp: msg }, res, () => t.fail())
 
-  t.false(logStub.calledOnce)
+  t.true(logStub.calledOnce)
   t.true(emitStub.calledOnce)
   t.true(sendStub.calledOnce)
 })
@@ -107,24 +107,20 @@ test('Receiver.emitHandler() w/o debug', t => {
 test('Receiver.logCommand() no command', t => {
   let receiver = new Receiver()
 
-  let logStub = sinon.stub(console, 'log')
+  let logStub = sinon.stub(receiver.log, 'debug')
   receiver.logCommand()
 
   t.true(logStub.calledWith('Command: UNKNOWN'))
-
-  console.log.restore()
 })
 
 test('Receiver.logCommand() no command prop', t => {
   let receiver = new Receiver()
   let cmd = {}
-  let logStub = sinon.stub(console, 'log')
+  let logStub = sinon.stub(receiver.log, 'debug')
 
   receiver.logCommand(cmd)
 
   t.true(logStub.calledWith('Command: Missing:', cmd))
-
-  console.log.restore()
 })
 
 test('Receiver.logCommand()', t => {
@@ -134,7 +130,7 @@ test('Receiver.logCommand()', t => {
     user_id: 'user_id',
     text: 'allthebots'
   }
-  let logStub = sinon.stub(console, 'log')
+  let logStub = sinon.stub(receiver.log, 'debug')
 
   receiver.logCommand(cmd)
 
@@ -142,19 +138,15 @@ test('Receiver.logCommand()', t => {
   t.true(text.indexOf(cmd.command) >= 0)
   t.true(text.indexOf(cmd.user_id) >= 0)
   t.true(text.indexOf(cmd.text) >= 0)
-
-  console.log.restore()
 })
 
 test('Receiver.logAction() no action', t => {
   let receiver = new Receiver()
 
-  let logStub = sinon.stub(console, 'log')
+  let logStub = sinon.stub(receiver.log, 'debug')
   receiver.logAction()
 
   t.true(logStub.calledWith('Action: UNKNOWN'))
-
-  console.log.restore()
 })
 
 test('Receiver.logAction()', t => {
@@ -162,35 +154,29 @@ test('Receiver.logAction()', t => {
   let action = {
     'beep': 'boop'
   }
-  let logStub = sinon.stub(console, 'log')
+  let logStub = sinon.stub(receiver.log, 'debug')
 
   receiver.logAction(action)
 
   t.true(logStub.calledWith('Action:', action))
-
-  console.log.restore()
 })
 
 test('Receiver.logEvent() no event', t => {
   let receiver = new Receiver()
 
-  let logStub = sinon.stub(console, 'log')
+  let logStub = sinon.stub(receiver.log, 'debug')
   receiver.logEvent()
 
   t.true(logStub.calledWith('Event: UNKNOWN'))
-
-  console.log.restore()
 })
 
 test('Receiver.logEvent() no event prop', t => {
   let receiver = new Receiver()
   let event = {}
-  let logStub = sinon.stub(console, 'log')
+  let logStub = sinon.stub(receiver.log, 'debug')
   receiver.logEvent(event)
 
   t.true(logStub.calledWith('Event: Missing:', event))
-
-  console.log.restore()
 })
 
 test('Receiver.logEvent() unspecified type', t => {
@@ -201,14 +187,12 @@ test('Receiver.logEvent() unspecified type', t => {
       user: 'user'
     }
   }
-  let logStub = sinon.stub(console, 'log')
+  let logStub = sinon.stub(receiver.log, 'debug')
   receiver.logEvent(event)
 
   let text = logStub.getCall(0).args[0]
   t.true(text.indexOf(event.event.type) >= 0)
   t.true(text.indexOf(event.event.user) >= 0)
-
-  console.log.restore()
 })
 
 test('Receiver.logEvent() reaction_added', t => {
@@ -224,7 +208,7 @@ test('Receiver.logEvent() reaction_added', t => {
       reaction: 'reaction'
     }
   }
-  let logStub = sinon.stub(console, 'log')
+  let logStub = sinon.stub(receiver.log, 'debug')
   receiver.logEvent(event)
 
   let text = logStub.getCall(0).args[0]
@@ -233,8 +217,6 @@ test('Receiver.logEvent() reaction_added', t => {
   t.true(text.indexOf(event.event.item.type) >= 0)
   t.true(text.indexOf(event.event.item.channel) >= 0)
   t.true(text.indexOf(event.event.reaction) >= 0)
-
-  console.log.restore()
 })
 
 test('Receiver.logEvent() message', t => {
@@ -247,7 +229,7 @@ test('Receiver.logEvent() message', t => {
       text: 'event text'
     }
   }
-  let logStub = sinon.stub(console, 'log')
+  let logStub = sinon.stub(receiver.log, 'debug')
   receiver.logEvent(event)
 
   let text = logStub.getCall(0).args[0]
@@ -255,8 +237,6 @@ test('Receiver.logEvent() message', t => {
   t.true(text.indexOf(event.event.user) >= 0)
   t.true(text.indexOf(event.event.channel) >= 0)
   t.true(text.indexOf(event.event.text) >= 0)
-
-  console.log.restore()
 })
 
 test('Receiver.logEvent() message w/ subtype', t => {
@@ -270,7 +250,7 @@ test('Receiver.logEvent() message w/ subtype', t => {
       text: 'event text'
     }
   }
-  let logStub = sinon.stub(console, 'log')
+  let logStub = sinon.stub(receiver.log, 'debug')
   receiver.logEvent(event)
 
   let text = logStub.getCall(0).args[0]
@@ -279,8 +259,6 @@ test('Receiver.logEvent() message w/ subtype', t => {
   t.true(text.indexOf(event.event.user) >= 0)
   t.true(text.indexOf(event.event.channel) >= 0)
   t.true(text.indexOf(event.event.text) >= 0)
-
-  console.log.restore()
 })
 
 function getMockMessage () {

--- a/test/slackapp.test.js
+++ b/test/slackapp.test.js
@@ -7,15 +7,18 @@ const Message = require('../src/message')
 
 test('Slapp()', t => {
   let options = {
-    debug: true,
+    log: true,
+    colors: true,
+    verify_token: 'verify_token',
     convo_store: () => {},
-    error: () => {}
+    tokens_lookup: () => {}
   }
 
   let app = new Slapp(options)
 
-  t.is(app.debug, options.debug)
+  t.is(app.log, options.log)
   t.is(app.convoStore, options.convo_store)
+  t.is(app.verify_token, options.verify_token)
   t.is(typeof app.client, 'object')
   t.is(typeof app.receiver, 'object')
   t.true(Array.isArray(app._middleware))
@@ -49,15 +52,6 @@ test('Slapp.init()', t => {
   app.init()
 
   t.is(app._middleware.length, 2)
-})
-
-test('Slapp.emit(error)', t => {
-  let app = new Slapp()
-  let logSpy = sinon.spy(app.log, 'error')
-
-  app.init().emit('error', 'kaboom')
-  t.is(app._middleware.length, 2)
-  t.true(logSpy.calledOnce)
 })
 
 test('Slapp.attachToExpress()', t => {


### PR DESCRIPTION
This PR updates the default logging to look a bit nicer.

![image](https://cloud.githubusercontent.com/assets/367275/17305647/98ec13bc-57e8-11e6-83a2-a059ea83f6a3.png)

+ `Slapp` is an `EventEmitter` that emits an `error` and `info` event that can be used for custom logging.
+ `log` boolean config option for enable/disable logging
+ `colors` boolean config option to enable/disable color logs
+ removes `error` config property, client can just listen to `error` event
+ removes `debug` config property
+ Throw error for incorrect type of ConvoStore` [adds test for this]
+ Simplified the `ConvoStore` creation inside the `Slapp` constructor.  If `opts.convo_store` isn't set, it will still just create a default memory store`
