### PR TITLE
Add regex matches to message callback

### DIFF
--- a/src/slapp.js
+++ b/src/slapp.js
@@ -304,12 +304,25 @@ class Slapp {
    * ##### Parameters
    * - `criteria` text that message contains or regex (e.g. "^hi")
    * - `typeFilter` [optional] Array for multiple values or string for one value. Valid values are `direct_message`, `direct_mention`, `mention`, `ambient`
-   * - `callback` function - `(msg) => {}`
+   * - `callback` function - `(msg, text, [match1], [match2]...) => {}`
    *
    *
    * ##### Returns
    * - `this` (chainable)
    *
+   * Example with regex matchers:
+   *
+   *     slapp.message('^play (song|artist) <([^>]+)>', (msg, text, type, toplay) => {
+   *       // text = 'play artist spotify:track:1yJiE307EBIzOB9kqH1deb'
+   *       // type = 'artist'
+   *       // toplay = 'spotify:track:1yJiE307EBIzOB9kqH1deb'
+   *     }
+   *
+   * Example without matchers:
+   *
+   *     slapp.message('play', (msg, text) => {
+   *       // text = 'play'
+   *     }
    *
    * Example `msg.body`:
    *

--- a/src/slapp.js
+++ b/src/slapp.js
@@ -350,8 +350,9 @@ class Slapp {
     let fn = (msg) => {
       if (msg.isMessage()) {
         let text = msg.stripDirectMention()
-        if (criteria.test(text) && (typeFilter.length === 0 || msg.isAnyOf(typeFilter))) {
-          callback(msg, text)
+        let match = text.match(criteria)
+        if (match && (typeFilter.length === 0 || msg.isAnyOf(typeFilter))) {
+          callback.apply(null, [msg].concat(match))
           return true
         }
       }

--- a/test/slackapp.test.js
+++ b/test/slackapp.test.js
@@ -430,6 +430,31 @@ test.cb('Slapp.message() w/o filter', t => {
     })
 })
 
+test.cb('Slapp.message() w/ matchers', t => {
+  t.plan(6)
+
+  let app = new Slapp()
+  let message = new Message('event', {
+    event: {
+      type: 'message',
+      text: 'beep one Two'
+    }
+  }, {})
+
+  app
+    .message('beep ([oO]ne) ([tT]wo)', (msg, text, match1, match2) => {
+      t.deepEqual(msg, message)
+      t.is(text, 'beep one Two')
+      t.is(match1, 'one')
+      t.is(match2, 'Two')
+    })
+    ._handle(message, (err, handled) => {
+      t.is(err, null)
+      t.true(handled)
+      t.end()
+    })
+})
+
 test.cb('Slapp.message() w/ filter', t => {
   t.plan(3)
 

--- a/test/slackapp.test.js
+++ b/test/slackapp.test.js
@@ -27,7 +27,7 @@ test('Slapp()', t => {
   t.is(app._middleware.length, 0)
 })
 
-test('Slackapp.use()', t => {
+test('Slapp.use()', t => {
   let mw = () => {}
   let app = new Slapp()
 
@@ -55,7 +55,7 @@ test('Slapp.init()', t => {
   t.is(app._middleware.length, 2)
 })
 
-test('Slackapp.attachToExpress()', t => {
+test('Slapp.attachToExpress()', t => {
   let app = new Slapp()
   let stub = sinon.stub(app.receiver, 'attachToExpress')
 


### PR DESCRIPTION
Pass regex matches through to message callback

For example, the two matchers `type` and `toplay` are passed as additional parameters:
```
slapp.message('^play (song|artist|playlist) <([^>]+)>', (msg, text, type, toplay) => {})
```