### PR TITLE
Make responseUrl for msg.respond optional

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -160,21 +160,44 @@ class Message {
    * `input` options are the same as [`say`](#messagesay)
    *
    * ##### Parameters
-   * - `responseUrl` string - URL provided by a Slack interactive message action or slash command
+   * - `responseUrl` string - URL provided by a Slack interactive message action or slash command [optional]
    * - `input` the payload to send, maybe a string, Object or Array.
    * - `callback` (err, data) => {}
+   *
+   * Example:
+   *
+   *     // responseUrl implied from body.response_url if this is an action or command
+   *     msg.respond('thanks!', (err) => {})
+   *
+   *     // responseUrl explicitly provided
+   *     msg.respond(responseUrl, 'thanks!', (err) => {})
+   *
+   *     // input provided as object
+   *     msg.respond({ text: 'thanks!' }, (err) => {})
+   *
+   *     // input provided as Array
+   *     msg.respond(['thanks!', 'I :heart: u'], (err) => {})
    *
    *
    * ##### Returns
    * - `this` (chainable)
    *
-   * @param {string} responseUrl
+   * @param {string} [responseUrl]
    * @param {(string|Object|Array)} input
    * @param {function} callback
    */
 
   respond (responseUrl, input, callback) {
+    if (!input || typeof input === 'function') {
+      callback = input
+      input = responseUrl
+      responseUrl = this.body.response_url
+    }
     if (!callback) callback = () => {}
+
+    if (!responseUrl) {
+      return callback(new Error('responseUrl not provided or not included as response_url with this type of Slack event'))
+    }
 
     this._request(responseUrl, this._processInput(input), (err, res, body) => {
       let rateLimit = 'You are sending too many requests. Please relax.'

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -317,6 +317,35 @@ test('Message.respond() w/o callback', t => {
   t.true(reqStub.calledOnce)
 })
 
+test('Message.respond() w/o responseUrl', t => {
+  let msg = new Message()
+  let url = 'https://slack'
+  let input = 'beepboop'
+
+  msg.body.response_url = url
+
+  let reqStub = sinon.stub(msg, '_request', (responseUrl, input, cb) => {
+    t.is(responseUrl, url)
+    t.is(input, input)
+
+    cb(null, {}, { ok: true })
+  })
+
+  msg.respond(input)
+  t.true(reqStub.calledOnce)
+})
+
+test('Message.respond() w/o responseUrl and response_url missing from body', t => {
+  t.plan(2)
+  let msg = new Message()
+  let input = 'beepboop'
+
+  msg.respond(input, (err) => {
+    t.truthy(err)
+    t.is(err.message, 'responseUrl not provided or not included as response_url with this type of Slack event')
+  })
+})
+
 test('Message.isMessage()', t => {
   let msg = new Message('event', {
     event: {


### PR DESCRIPTION
This simply makes the first parameter of `msg.respond` optional. If not included, `msg.body.response_url` will be implied and will pass an error to the `callback` if not found.

Tests kept at 100%

fixes #21