### PR TITLE
Add regex matchers for commands

### DIFF
--- a/src/slapp.js
+++ b/src/slapp.js
@@ -450,7 +450,7 @@ class Slapp extends EventEmitter {
    * ##### Parameters
    * - `callbackId` string
    * - `actionNameCriteria` string or RegExp - the name of the action [optional]
-   * - `callback` function - `(msg) => {}`
+   * - `callback` function - `(msg, text, [match1], [match2]...) => {}`
    *
    *
    * ##### Returns
@@ -566,6 +566,21 @@ class Slapp extends EventEmitter {
    * ##### Returns
    * - `this` (chainable)
    *
+   * Example without parameters:
+   *
+   *     // "/acommand"
+   *     slapp.command('acommand', (msg) => {
+   *     }
+   *
+   *
+   * Example with RegExp matcher criteria:
+   *
+   *     // "/acommand create flipper"
+   *     slapp.command('acommand', 'create (.*)'(msg, text, name) => {
+   *       // text = 'create flipper'
+   *       // name = 'flipper'
+   *     }
+   *
    *
    * Example `msg` object:
    *
@@ -610,9 +625,13 @@ class Slapp extends EventEmitter {
     }
 
     let fn = (msg) => {
-      if (msg.type === 'command' && msg.body.command === command && criteria.test(msg.body.text)) {
-        callback(msg)
-        return true
+      if (msg.type === 'command' && msg.body.command === command) {
+        let text = msg.body.text || ''
+        let match = text.match(criteria)
+        if (match) {
+          callback.apply(null, [msg].concat(match))
+          return true
+        }
       }
     }
 

--- a/test/slackapp.test.js
+++ b/test/slackapp.test.js
@@ -283,6 +283,33 @@ test.cb('Slapp.command() w/ criteria regex', t => {
     })
 })
 
+test.cb('Slapp.command() w/ criteria matcher', t => {
+  t.plan(6)
+
+  let app = new Slapp()
+  let message = {
+    attachSlapp () {},
+    type: 'command',
+    body: {
+      command: 'test',
+      text: 'one two'
+    }
+  }
+
+  app
+    .command(message.body.command, '([oO]ne) ([tT]wo)', (msg, text, match1, match2) => {
+      t.deepEqual(msg, message)
+      t.is(text, message.body.text)
+      t.is(match1, 'one')
+      t.is(match2, 'two')
+    })
+    ._handle(message, (err, handled) => {
+      t.is(err, null)
+      t.true(handled)
+      t.end()
+    })
+})
+
 test.cb('Slapp.command() w/ non-matching string criteria', t => {
   t.plan(2)
 


### PR DESCRIPTION
Adds matcher parameters to commands just like they are for `slapp.message`.

For example:

```
// "/acommand create flipper"
slapp.command('acommand', 'create (.*)'(msg, text, name) => {
  // text = 'create flipper'
  // name = 'flipper'
}
```
