### PR TITLE
removes requirement of user_id and channel_id

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -27,8 +27,8 @@ class Message {
     this.meta = meta || {}
     this.conversation_id = [
       this.meta.team_id,
-      this.meta.channel_id,
-      this.meta.user_id || this.meta.bot_id
+      this.meta.channel_id || 'nochannel',
+      this.meta.user_id || this.meta.bot_id || 'nouser'
     ].join('::')
 
     this._slapp = null
@@ -464,8 +464,6 @@ class Message {
 
     if (!this.meta.app_token) missing.push('app_token')
     if (!this.meta.team_id) missing.push('team_id')
-    if (!this.meta.channel_id) missing.push('channel_id')
-    if (!this.meta.user_id && !this.meta.bot_id) missing.push('user_id||bot_id')
 
     if (missing.length === 0) {
       return null

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -44,6 +44,26 @@ test('Message() w/o user_id', t => {
   t.is(msg.conversation_id, 'team_id::channel_id::bot_id')
 })
 
+test('Message() w/o user_id, bot_id, or channel_id', t => {
+  let type = 'event'
+  let body = {
+    text: 'beepboop'
+  }
+  let meta = {
+    app_token: 'asdf',
+    team_id: 'team_id'
+  }
+  let msg = new Message(type, body, meta)
+  let err = msg.verifyProps()
+
+  t.is(err, null)
+  t.is(msg.type, type)
+  t.deepEqual(msg.body, body)
+  t.deepEqual(msg.meta, meta)
+  t.is(msg._slapp, null)
+  t.is(msg.conversation_id, 'team_id::nochannel::nouser')
+})
+
 test('Message() defaults', t => {
   let msg = new Message()
 


### PR DESCRIPTION
Some events don't have a `user_id` or a `channel_id`, so removing the requirement of those, and handling that case where they're empty in creating the `message.conversation_id`.  Since some events don't have a channel, calling things like `msg.say()` in those cases will require passing in the channel you would need, which I think is fair.