### PR TITLE
Template strings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ var slapp = Slapp({ context: BeepBoopContext() })
 
 slapp.message('^(hi|hello|hey).*', ['direct_mention', 'direct_message'], (msg, text, greeting) => {
   msg
-    .say(greeting + ', how are you?')
+    .say(`${greeting}, how are you?`)
     .route('handleHowAreYou')  // where to route the next msg in the conversation
 })
 


### PR DESCRIPTION
I noticed that Travis is only testing this project in Node 4+ which natively supports template strings. This change only updates the `README`, though there are other actual usages in the codebase that would look cleaner as template strings instead of string concatenation -- I could take care of those in this PR if that sounds reasonable.