### PR TITLE
passes callback into convoStore.set

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -106,7 +106,11 @@ class Message {
 
     let key = this.conversation_id
     let expiration = Date.now() + secondsToExpire * 1000
-    this._slapp.convoStore.set(key, { fnKey, state, expiration })
+    this._slapp.convoStore.set(key, { fnKey, state, expiration }, (err) => {
+      if (err) {
+        this._slapp.emit('error', err)
+      }
+    })
     return this
   }
 

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -149,6 +149,32 @@ test('Message.route() defaults', t => {
   t.true(setStub.calledOnce)
 })
 
+test('Message.route() w/ convoStore.set error', t => {
+  t.plan(2)
+
+  let msg = new Message()
+  msg.conversation_id = 'beepboop'
+  let fnKey = 'next:route'
+  let state = {
+    beep: 'boop'
+  }
+  let app = {
+    emit: () => {},
+    convoStore: {
+      set: () => {}
+    }
+  }
+  let setStub = sinon.stub(app.convoStore, 'set', (key, data, done) => {
+    done('boom')
+  })
+  let emitSpy = sinon.spy(app, 'emit')
+
+  msg._slapp = app
+  msg.route(fnKey, state, 60)
+  t.true(setStub.calledOnce)
+  t.true(emitSpy.calledWith('error', 'boom'))
+})
+
 test('Message.cancel()', t => {
   t.plan(2)
 


### PR DESCRIPTION
Fixes #35 

+ Passes a callback into `convoStore.set()` in `message.route()`
+ If there's an error during the set, we emit an `error` on the `slapp` instance