### PR TITLE
exposes slack client lib

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,0 +1,1 @@
+module.exports = require('slack')


### PR DESCRIPTION
Adds file to expose `slack` client lib via:

```js
const slack = require('slapp/client')
```

Fixes #32 