### PR TITLE
emits error on slapp for slack api errors inside msg.say and msg.respond

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "npm run lint && npm run coverage",
     "lint": "standard",
-    "unit": "ava --verbose",
-    "coverage": "nyc --check-coverage --statements 100 ava --verbose",
+    "unit": "ava --verbose --serial",
+    "coverage": "nyc --check-coverage --statements 100 ava --verbose --serial",
     "lcov": "nyc --reporter lcov ava",
     "docs": "node scripts/docs.js",
     "coveralls": "npm run lcov && cat ./coverage/lcov.info | coveralls"


### PR DESCRIPTION
Goal of this PR is to make sure we're logging/emitting errors that may occur from calls to `msg.say()` and `msg.respond`.  Adds a call to `msg._slapp.emit('error', err)` inside of the slack api callbacks in `msg.say()` and `msg.respond()`

+ Had to change ava to run tests serially due to mocking some global functions, i.e. `slack.chat.postMessage()`.  Adding another test that mocks that seems to have hit some threshold where they were running concurrently and the sinon stubs were clashing.
+ Refactored the `msg.respond()` request callback to avoid some redundancy and normalize the errors prior to calling the callback and emitting the error if it exists.