### PR TITLE
Add value match to slapp.action matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,12 +596,28 @@ slapp.route('handleDoitConfirmation', (msg, state) => {
 #### Parameters
   - `callbackId` string
   - `actionNameCriteria` string or RegExp - the name of the action [optional]
+  - `actionValueCriteria` string or RegExp - the value of the action [optional]
   - `callback` function - `(msg, text, [match1], [match2]...) => {}`
   
   
 #### Returns
   - `this` (chainable)
   
+  Example:
+  
+```js
+  // match name and value
+  slapp.action('dinner_callback', 'drink', 'beer', (msg, val) => {}
+  // match name and value either beer or wine
+  slapp.action('dinner_callback', 'drink', '(beer|wine)', (msg, val) => {}
+  // match name drink, any value
+  slapp.action('dinner_callback', 'drink', (msg, val) => {}
+  // match dinner_callback, any name or value
+  slapp.action('dinner_callback', 'drink', (msg, val) => {}
+  // match with regex
+  slapp.action('dinner_callback', /^drink$/, /^b[e]{2}r$/, (msg, val) => {}
+```
+
   
   Example `msg.body` object:
   

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "standard",
     "unit": "ava --verbose --serial",
     "coverage": "nyc --check-coverage --statements 100 ava --verbose --serial",
-    "lcov": "nyc --reporter lcov ava",
+    "lcov": "nyc --reporter lcov ava --serial",
     "docs": "node scripts/docs.js",
     "coveralls": "npm run lcov && cat ./coverage/lcov.info | coveralls"
   },

--- a/test/slapp.test.js
+++ b/test/slapp.test.js
@@ -369,7 +369,7 @@ test.cb('Slapp.action() w/o criteria', t => {
     })
 })
 
-test.cb('Slapp.action() w/ criteria string', t => {
+test.cb('Slapp.action() w/ name criteria string', t => {
   t.plan(3)
 
   let app = new Slapp({ context })
@@ -383,6 +383,52 @@ test.cb('Slapp.action() w/ criteria string', t => {
 
   app
     .action(message.body.callback_id, 'beep', (msg) => {
+      t.deepEqual(msg, message)
+    })
+    ._handle(message, (err, handled) => {
+      t.is(err, null)
+      t.true(handled)
+      t.end()
+    })
+})
+
+test.cb('Slapp.action() w/ name and value criteria string', t => {
+  t.plan(3)
+
+  let app = new Slapp({ context })
+  let message = new Message('action', {
+    actions: [
+      { name: 'beep', value: 'boop' }
+    ],
+    callback_id: 'my_callback',
+    command: 'test'
+  }, meta)
+
+  app
+    .action(message.body.callback_id, 'beep', 'boop', (msg) => {
+      t.deepEqual(msg, message)
+    })
+    ._handle(message, (err, handled) => {
+      t.is(err, null)
+      t.true(handled)
+      t.end()
+    })
+})
+
+test.cb('Slapp.action() w/ name and value criteria regex', t => {
+  t.plan(3)
+
+  let app = new Slapp({ context })
+  let message = new Message('action', {
+    actions: [
+      { name: 'beep', value: 'Boop' }
+    ],
+    callback_id: 'my_callback',
+    command: 'test'
+  }, meta)
+
+  app
+    .action(message.body.callback_id, /^beep.*/, /B[o]{2}p/, (msg) => {
       t.deepEqual(msg, message)
     })
     ._handle(message, (err, handled) => {


### PR DESCRIPTION
The PR adds the ability to match on the value of an action. Currently we can only match on the name which means you have to do something like this:

```js
slapp.action('dinner_callback', 'drink', (msg, val) => {
  if (val === 'yes') {
    // handle yes
  }
  if (val === 'no') {
    // handle no
  }
})
```

The new value matching parameter will allow this:

```js
slapp.action('dinner_callback', 'drink', 'yes', (msg, val) => {
    // handle yes
})

slapp.action('dinner_callback', 'drink', 'no', (msg, val) => {
    // handle no
})
```

Added test, coverage kept at 100%

![split](https://cloud.githubusercontent.com/assets/30455/17894199/c7f531c4-6905-11e6-94ce-0f2ff8a4a302.gif)
