### PR TITLE
only ignore bot_message subtypes in ignoreBotsMiddleware

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -253,6 +253,15 @@ class Message {
   }
 
   /**
+   * Is this from a bot user?
+   *
+   * ##### Returns `bool` true if `this` is a message from a bot user
+   */
+  isBot () {
+    return !!(this.meta.bot_id || (this.meta.user_id && this.meta.user_id === this.meta.bot_user_id))
+  }
+
+  /**
    * Is this an `event` of type `message`?
    *
    *

--- a/src/slapp.js
+++ b/src/slapp.js
@@ -125,8 +125,7 @@ class Slapp extends EventEmitter {
 
   ignoreBotsMiddleware () {
     return (msg, next) => {
-      // avoid the case where both user_id and bot_user_id not set
-      if (msg.meta.bot_id || (msg.meta.user_id && msg.meta.user_id === msg.meta.bot_user_id)) {
+      if (msg.isBot() && msg.isMessage() && msg.body.event.subtype === 'bot_message') {
         return
       }
       next()

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -517,6 +517,43 @@ test.cb('Message.respond() multiple in series', t => {
   }
 })
 
+test('Message.isBot() w/ bot_id', t => {
+  let msg = new Message('event', {}, {
+    bot_id: 'bot_id'
+  })
+  t.true(msg.isBot())
+})
+
+test('Message.isBot() w/o any ids', t => {
+  let msg = new Message('event', {}, {})
+  t.false(msg.isBot())
+})
+
+test('Message.isBot() w/o matching user_id and bot_user_id', t => {
+  let msg = new Message('event', {}, {
+    user_id: 'asdf',
+    bot_user_id: 'fdsa'
+  })
+  t.false(msg.isBot())
+})
+
+test('Message.isBot() w/ matching user_id and bot_user_id', t => {
+  let msg = new Message('event', {}, {
+    user_id: 'asdf',
+    bot_user_id: 'asdf'
+  })
+  t.true(msg.isBot())
+})
+
+test('Message.isBot() w/ bot_id and matching user_id and bot_user_id', t => {
+  let msg = new Message('event', {}, {
+    bot_id: 'bot_id',
+    user_id: 'asdf',
+    bot_user_id: 'asdf'
+  })
+  t.true(msg.isBot())
+})
+
 test('Message.isMessage()', t => {
   let msg = new Message('event', {
     event: {

--- a/test/slapp.test.js
+++ b/test/slapp.test.js
@@ -595,11 +595,16 @@ test.cb('Slapp._handle() w/ init()', t => {
     })
 })
 
-test.cb('Slapp.ignoreBotsMiddleware() with bot message', t => {
+test.cb('Slapp.ignoreBotsMiddleware() with bot_message and bot_id', t => {
   let app = new Slapp({ context })
   let mw = app.ignoreBotsMiddleware()
 
-  let message = new Message('event', {}, {
+  let message = new Message('event', {
+    event: {
+      type: 'message',
+      subtype: 'bot_message'
+    }
+  }, {
     bot_id: 'asdf'
   }, meta)
 
@@ -609,6 +614,24 @@ test.cb('Slapp.ignoreBotsMiddleware() with bot message', t => {
   })
   t.pass()
   t.end()
+})
+
+test.cb('Slapp.ignoreBotsMiddleware() with bot_message no bot_id', t => {
+  let app = new Slapp({ context })
+  let mw = app.ignoreBotsMiddleware()
+
+  let message = new Message('event', {
+    event: {
+      type: 'message',
+      subtype: 'bot_message'
+    }
+  }, {}, meta)
+
+  // this callback is synchronous
+  mw(message, () => {
+    t.pass()
+    t.end()
+  })
 })
 
 test.cb('Slapp.ignoreBotsMiddleware() w/o bot message', t => {


### PR DESCRIPTION
This PR Updates `ignoreBotsMiddleware()` to only ignore messages with a `subtype` of `bot_message`.  This allows apps to listen to events w/ a `bot_id` like when the bot joins a channel.

+ Added a `Message.isBot()` function that's used as part of this PR.

Fixes #33 