### PR TITLE
Command as regex matcher

### DIFF
--- a/src/slapp.js
+++ b/src/slapp.js
@@ -446,7 +446,7 @@ class Slapp extends EventEmitter {
 
   event (criteria, callback) {
     if (typeof criteria === 'string') {
-      criteria = new RegExp('^' + criteria + '$', 'i')
+      criteria = new RegExp(`^${criteria}$`, 'i')
     }
     let fn = (msg) => {
       if (msg.type === 'event' && msg.body.event && criteria.test(msg.body.event.type)) {
@@ -570,11 +570,11 @@ class Slapp extends EventEmitter {
     }
 
     if (typeof actionNameCriteria === 'string') {
-      actionNameCriteria = new RegExp('^' + actionNameCriteria + '$', 'i')
+      actionNameCriteria = new RegExp(`^${actionNameCriteria}$`, 'i')
     }
 
     if (typeof actionValueCriteria === 'string') {
-      actionValueCriteria = new RegExp('^' + actionValueCriteria + '$', 'i')
+      actionValueCriteria = new RegExp(`^${actionValueCriteria}$`, 'i')
     }
 
     let fn = (msg) => {
@@ -661,9 +661,12 @@ class Slapp extends EventEmitter {
     if (typeof criteria === 'string') {
       criteria = new RegExp(criteria, 'i')
     }
+    if (typeof command === 'string') {
+      command = new RegExp(`^${command}$`, 'i')
+    }
 
     let fn = (msg) => {
-      if (msg.type === 'command' && msg.body.command === command) {
+      if (msg.type === 'command' && msg.body.command && msg.body.command.match(command)) {
         let text = msg.body.text || ''
         let match = text.match(criteria)
         if (match) {

--- a/test/slapp.test.js
+++ b/test/slapp.test.js
@@ -247,6 +247,66 @@ test.cb('Slapp.command() w/o criteria', t => {
     })
 })
 
+test.cb('Slapp.command() w/ command regex', t => {
+  t.plan(3)
+
+  let app = new Slapp({ context })
+  let message = new Message('command', {
+    command: '/test',
+    text: 'hello'
+  }, meta)
+
+  app
+    .command(/\/tes.*/, /llo$/, (msg) => {
+      t.deepEqual(msg, message)
+    })
+    ._handle(message, (err, handled) => {
+      t.is(err, null)
+      t.true(handled)
+      t.end()
+    })
+})
+
+test.cb('Slapp.command() w/ command string regex', t => {
+  t.plan(3)
+
+  let app = new Slapp({ context })
+  let message = new Message('command', {
+    command: '/test',
+    text: 'hello'
+  }, meta)
+
+  app
+    .command('/tes.*', /llo$/, (msg) => {
+      t.deepEqual(msg, message)
+    })
+    ._handle(message, (err, handled) => {
+      t.is(err, null)
+      t.true(handled)
+      t.end()
+    })
+})
+
+test.cb('Slapp.command() w/ command string regex and redundant ^$', t => {
+  t.plan(3)
+
+  let app = new Slapp({ context })
+  let message = new Message('command', {
+    command: '/test',
+    text: 'hello'
+  }, meta)
+
+  app
+    .command('^^/test$$', /llo$/, (msg) => {
+      t.deepEqual(msg, message)
+    })
+    ._handle(message, (err, handled) => {
+      t.is(err, null)
+      t.true(handled)
+      t.end()
+    })
+})
+
 test.cb('Slapp.command() w/ criteria string', t => {
   t.plan(3)
 


### PR DESCRIPTION
Makes the matching for a Slack command similar to how we match on other types. The command name can now be:

- simple string: `"/test"`
- regex string: `"/tes.*"`
- RegExp: `/\/tes.*/`

