### PR TITLE
stripDirectMention should handle undefined text

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -437,7 +437,7 @@ class Message {
   stripDirectMention () {
     var text = ''
     if (this.isMessage()) {
-      text = this.body.event.text
+      text = this.body.event.text || ''
       let match = text.match(new RegExp(`^<@${this.meta.bot_user_id}>:{0,1}(.*)`))
       if (match) {
         text = match[1].trim()

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -635,6 +635,20 @@ test('Message.stripDirectMention()', t => {
   t.is(msg.stripDirectMention(), 'how you doing?')
 })
 
+test('Message.stripDirectMention() w/ undefined text', t => {
+  let botUserId = 'bot_user_id'
+  let msg = new Message('event', {
+    event: {
+      type: 'message',
+      text: undefined
+    }
+  }, {
+    bot_user_id: botUserId
+  })
+
+  t.is(msg.stripDirectMention(), '')
+})
+
 test('Message._processInput() with array', t => {
   let msg = new Message()
   let vals = ['one', 'two', 'three']


### PR DESCRIPTION
Fixes #48.

Fix undefined reference causing crash when test property is not included in message.
