### PR TITLE
Add isBaseMessage to mitigate sub_type issue

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -265,11 +265,24 @@ class Message {
    * Is this an `event` of type `message`?
    *
    *
+   * Marked as private until we figure out how to properly handle all of the other subtypes
+   * @api private
    * ##### Returns `bool` true if `this` is a message event type
    */
 
   isMessage () {
     return !!(this.type === 'event' && this.body.event && this.body.event.type === 'message')
+  }
+
+  /**
+   * Is this an `event` of type `message` without any [subtype](https://api.slack.com/events/message)?
+   *
+   *
+   * ##### Returns `bool` true if `this` is a message event type with no subtype
+   */
+
+  isBaseMessage () {
+    return this.isMessage() && !this.body.event.subtype
   }
 
   /**
@@ -280,7 +293,7 @@ class Message {
    */
 
   isDirectMention () {
-    return this.isMessage() && new RegExp(`^<@${this.meta.bot_user_id}>`, 'i').test(this.body.event.text)
+    return this.isBaseMessage() && new RegExp(`^<@${this.meta.bot_user_id}>`, 'i').test(this.body.event.text)
   }
 
   /**
@@ -291,7 +304,7 @@ class Message {
    */
 
   isDirectMessage () {
-    return this.isMessage() && this.meta.channel_id[0] === 'D'
+    return this.isBaseMessage() && this.meta.channel_id[0] === 'D'
   }
 
   /**
@@ -303,7 +316,7 @@ class Message {
    */
 
   isMention () {
-    return this.isMessage() && new RegExp(`<@${this.meta.bot_user_id}>`, 'i').test(this.body.event.text)
+    return this.isBaseMessage() && new RegExp(`<@${this.meta.bot_user_id}>`, 'i').test(this.body.event.text)
   }
 
   /**
@@ -315,7 +328,7 @@ class Message {
    */
 
   isAmbient () {
-    return this.isMessage() && !this.isMention() && !this.isDirectMessage()
+    return this.isBaseMessage() && !this.isMention() && !this.isDirectMessage()
   }
 
   /**
@@ -412,7 +425,7 @@ class Message {
     let re = new RegExp('<([^@^>]+)>', 'g')
     let matcher
 
-    if (this.isMessage()) {
+    if (this.isBaseMessage()) {
       do {
         matcher = re.exec(this.body.event.text)
         if (matcher) {
@@ -436,7 +449,7 @@ class Message {
 
   stripDirectMention () {
     var text = ''
-    if (this.isMessage()) {
+    if (this.isBaseMessage()) {
       text = this.body.event.text || ''
       let match = text.match(new RegExp(`^<@${this.meta.bot_user_id}>:{0,1}(.*)`))
       if (match) {
@@ -456,7 +469,7 @@ class Message {
     let matches = []
     let matcher
 
-    if (this.isMessage()) {
+    if (this.isBaseMessage()) {
       do {
         matcher = re.exec(this.body.event.text)
         if (matcher) {

--- a/src/slapp.js
+++ b/src/slapp.js
@@ -392,7 +392,7 @@ class Slapp extends EventEmitter {
     }
 
     let fn = (msg) => {
-      if (msg.isMessage()) {
+      if (msg.isBaseMessage()) {
         let text = msg.stripDirectMention()
         let match = text.match(criteria)
         if (match && (typeFilter.length === 0 || msg.isAnyOf(typeFilter))) {

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -593,6 +593,25 @@ test('Message.isMessage() wrong event.type', t => {
   t.false(msg.isMessage())
 })
 
+test('Message.isBaseMessage() true', t => {
+  let msg = new Message('event', {
+    event: {
+      type: 'message'
+    }
+  })
+  t.true(msg.isBaseMessage())
+})
+
+test('Message.isBaseMessage() false', t => {
+  let msg = new Message('event', {
+    event: {
+      type: 'message',
+      subtype: 'bot_message'
+    }
+  })
+  t.false(msg.isBaseMessage())
+})
+
 test('Message.isDirectMention() true', t => {
   let botUserId = 'bot_user_id'
   let msg = new Message('event', {


### PR DESCRIPTION
It turns out there are MANY `message` `subtypes` https://api.slack.com/events/message

Currently `slapp.message` doesn't filter by any of these types, it just consider `text` when matching most times. However, today we started receiving `message_changed` events for every updated interactive message and these messages include the `text` property.

So we need to more broadly consider how we match on subtypes of event types of `message` which would be a broader API change. This change "fixes" the current situation in a way that is in line with current expectations.