### PR TITLE
provide loggin option if verify token is incorrect

### DIFF
--- a/src/receiver/index.js
+++ b/src/receiver/index.js
@@ -20,6 +20,7 @@ module.exports = class Receiver extends EventEmitter {
 
     this.verify_token = opts.verify_token
     this.context = opts.context
+    this.log = opts.log
 
     // record all events to a JSON line delimited file if record is set
     if (opts.record) {
@@ -48,7 +49,7 @@ module.exports = class Receiver extends EventEmitter {
     })
 
     let emitHandler = this.emitHandler.bind(this)
-    let verifyToken = VerifyToken(this.verify_token)
+    let verifyToken = VerifyToken(this.verify_token, this.log)
     let sslCheck = SSLCheck()
 
     if (options.event) {

--- a/src/receiver/middleware/verify-token.js
+++ b/src/receiver/middleware/verify-token.js
@@ -1,6 +1,6 @@
 'use strict'
 
-module.exports = (token) => {
+module.exports = (token, shouldLog) => {
   return function verifyTokenMiddleware (req, res, next) {
     // If token isn't set, we're not verifying
     if (!token) {
@@ -12,6 +12,8 @@ module.exports = (token) => {
 
     // test verify token
     if (token !== verifyToken) {
+      // log when there's an inviald verify token
+      if (shouldLog) console.log('Invalid verify token')
       res.status(403).send('Invalid token')
       return
     }

--- a/test/middleware.verify-token.test.js
+++ b/test/middleware.verify-token.test.js
@@ -44,9 +44,9 @@ test.cb('VerifyToken() token option matching verify_token', t => {
   })
 })
 
-test('VerifyToken() token option matching verify_token', t => {
+test('VerifyToken() token option nonmatching verify_token', t => {
   let token = 'beepboop'
-  let mw = VerifyToken(token)
+  let mw = VerifyToken(token, true)
   let req = fixtures.getMockReq({
     slapp: {
       meta: {


### PR DESCRIPTION
Took me quite a while to figure out that slack changed my verify token. My bot just stopped working, it would be nice if slapp logged when an invalid verify token was passed. 

Let me know what you think of this approach of logging when an invalid auth token is found. 
