### PR TITLE
Correct channelsMentioned logic

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -372,7 +372,7 @@ class Message {
    */
 
   channelsMentioned () {
-    return this._regexMentions(new RegExp('<#(C[A-Za-z0-9]+)>', 'g'))
+    return this._regexMentions(new RegExp('<#(C[A-Za-z0-9]+)[^>]+>', 'g'))
   }
 
   /**

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -705,7 +705,7 @@ test('Message.channelsMentioned()', t => {
   let msg = new Message('event', {
     event: {
       type: 'message',
-      text: 'hi <#C1> do you know <#C2>?'
+      text: 'hi <#C1|channel1> do you know <#C2|channel2>?'
     }
   })
 


### PR DESCRIPTION
Slack changed up the way that channel mentions are represented in messages, so this change is required in order for `msg.channelsMentioned()` to work correctly.

Closes #53 
