### PR TITLE
Log invalid verify

### DIFF
--- a/src/receiver/index.js
+++ b/src/receiver/index.js
@@ -20,7 +20,6 @@ module.exports = class Receiver extends EventEmitter {
 
     this.verify_token = opts.verify_token
     this.context = opts.context
-    this.log = opts.log
 
     // record all events to a JSON line delimited file if record is set
     if (opts.record) {
@@ -49,7 +48,7 @@ module.exports = class Receiver extends EventEmitter {
     })
 
     let emitHandler = this.emitHandler.bind(this)
-    let verifyToken = VerifyToken(this.verify_token, this.log)
+    let verifyToken = VerifyToken(this.verify_token, this.emit.bind(this, 'error'))
     let sslCheck = SSLCheck()
 
     if (options.event) {

--- a/src/receiver/index.js
+++ b/src/receiver/index.js
@@ -20,6 +20,7 @@ module.exports = class Receiver extends EventEmitter {
 
     this.verify_token = opts.verify_token
     this.context = opts.context
+    this.log = opts.log
 
     // record all events to a JSON line delimited file if record is set
     if (opts.record) {
@@ -48,7 +49,7 @@ module.exports = class Receiver extends EventEmitter {
     })
 
     let emitHandler = this.emitHandler.bind(this)
-    let verifyToken = VerifyToken(this.verify_token)
+    let verifyToken = VerifyToken(this.verify_token, this.log)
     let sslCheck = SSLCheck()
 
     if (options.event) {

--- a/src/receiver/middleware/verify-token.js
+++ b/src/receiver/middleware/verify-token.js
@@ -1,6 +1,6 @@
 'use strict'
 
-module.exports = (token) => {
+module.exports = (token, shouldLog) => {
   return function verifyTokenMiddleware (req, res, next) {
     // If token isn't set, we're not verifying
     if (!token) {
@@ -12,6 +12,8 @@ module.exports = (token) => {
 
     // test verify token
     if (token !== verifyToken) {
+      // log when there's an inviald verify token
+      if (shouldLog) console.log('Invalid verify token')
       res.status(403).send('Invalid token')
       return
     }

--- a/src/receiver/middleware/verify-token.js
+++ b/src/receiver/middleware/verify-token.js
@@ -1,6 +1,6 @@
 'use strict'
 
-module.exports = (token, shouldLog) => {
+module.exports = (token, onError) => {
   return function verifyTokenMiddleware (req, res, next) {
     // If token isn't set, we're not verifying
     if (!token) {
@@ -12,9 +12,10 @@ module.exports = (token, shouldLog) => {
 
     // test verify token
     if (token !== verifyToken) {
-      // log when there's an inviald verify token
-      if (shouldLog) console.log('Invalid verify token')
-      res.status(403).send('Invalid token')
+      if (onError) {
+        onError('Invalid verify token')
+      }
+      res.status(403).send('Invalid verify token')
       return
     }
 

--- a/src/slapp.js
+++ b/src/slapp.js
@@ -87,7 +87,9 @@ class Slapp extends EventEmitter {
       })
     }
     // call `handle` for each new request
-    this.receiver.on('message', this._handle.bind(this))
+    this.receiver
+      .on('message', this._handle.bind(this))
+      .on('error', this.emit.bind(this, 'error'))
     this.use(this.ignoreBotsMiddleware())
     this.use(this.preprocessConversationMiddleware())
 

--- a/test/middleware.verify-token.test.js
+++ b/test/middleware.verify-token.test.js
@@ -44,9 +44,9 @@ test.cb('VerifyToken() token option matching verify_token', t => {
   })
 })
 
-test('VerifyToken() token option matching verify_token', t => {
+test('VerifyToken() token option nonmatching verify_token', t => {
   let token = 'beepboop'
-  let mw = VerifyToken(token)
+  let mw = VerifyToken(token, true)
   let req = fixtures.getMockReq({
     slapp: {
       meta: {

--- a/test/middleware.verify-token.test.js
+++ b/test/middleware.verify-token.test.js
@@ -23,7 +23,7 @@ test('VerifyToken() token option no verify_token', t => {
 
   mw(fixtures.getMockReq(), res, () => {})
   t.true(statusStub.calledWith(403))
-  t.true(sendStub.calledWith('Invalid token'))
+  t.true(sendStub.calledWith('Invalid verify token'))
 })
 
 test.cb('VerifyToken() token option matching verify_token', t => {
@@ -46,7 +46,8 @@ test.cb('VerifyToken() token option matching verify_token', t => {
 
 test('VerifyToken() token option nonmatching verify_token', t => {
   let token = 'beepboop'
-  let mw = VerifyToken(token, true)
+  let onError = sinon.stub()
+  let mw = VerifyToken(token, onError)
   let req = fixtures.getMockReq({
     slapp: {
       meta: {
@@ -61,5 +62,6 @@ test('VerifyToken() token option nonmatching verify_token', t => {
 
   mw(req, res, () => {})
   t.true(statusStub.calledWith(403))
-  t.true(sendStub.calledWith('Invalid token'))
+  t.true(sendStub.calledWith('Invalid verify token'))
+  t.true(onError.calledWith('Invalid verify token'))
 })


### PR DESCRIPTION
This PR bubbles up (and logs) an error when the verify token doesn't match on the incoming request.