### PR TITLE
Add ignoreSelfMiddleware and options to configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ One of the challenges with writing a multi-team Slack app is that you need to ma
 + `app_token` - **required** OAuth `access_token` property
 + `bot_token` - **required if you have a bot user** OAuth `bot.bot_access_token` property
 + `bot_user_id` - **required if you have a bot user** OAuth `bot.bot_user_id` property
++ `app_bot_id` - **required if you have a bot user and use ignoreSelf option** Profile call with bot token, `users.profile.bot_id` property
 
 The incoming request from Slack has been parsed and normalized by the time the `context` function runs, and is available via `req.slapp`.  You can rely on this data in your `context` function to assist you in looking up the necessary tokens and meta-data.
 
@@ -366,6 +367,8 @@ slapp.route('handleDoitConfirmation', (msg, state) => {
   - `opts.context` `Function (req, res, next)` HTTP Middleware function to enrich incoming request with context
   - `opts.log` defaults to `true`, `false` to disable logging
   - `opts.colors` defaults to `process.stdout.isTTY`, `true` to enable colors in logging
+  - `opts.ignoreSelf` defaults to `true`, `true` to automatically ignore any messages from yourself. This flag requires the context to set `meta.app_bot_id` with the Slack App's users.profile.bot_id.
+  - `opts.ignoreBots` defaults to `false`, `true` to ignore any messages from bot users automatically
   
   Example
   
@@ -780,7 +783,8 @@ It is generally always passed as `msg`.
   - [Message.say()](#messagesayinputstringobjectarraycallbackfunction)
   - [Message.respond()](#messagerespondresponseurlstringinputstringobjectarraycallbackfunction)
   - [Message._request()](#message_request)
-  - [Message.isMessage()](#messageismessage)
+  - [Message.isBot()](#messageisbot)
+  - [Message.isBaseMessage()](#messageisbasemessage)
   - [Message.isDirectMention()](#messageisdirectmention)
   - [Message.isDirectMessage()](#messageisdirectmessage)
   - [Message.isMention()](#messageismention)
@@ -885,12 +889,18 @@ It is generally always passed as `msg`.
 
   istanbul ignore next
 
-## Message.isMessage()
+## Message.isBot()
 
-  Is this an `event` of type `message`?
+  Is this from a bot user?
+  
+#### Returns `bool` true if `this` is a message from a bot user
+
+## Message.isBaseMessage()
+
+  Is this an `event` of type `message` without any [subtype](https://api.slack.com/events/message)?
   
   
-#### Returns `bool` true if `this` is a message event type
+#### Returns `bool` true if `this` is a message event type with no subtype
 
 ## Message.isDirectMention()
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,8 @@ const Slapp = require('./slapp')
  * - `opts.context` `Function (req, res, next)` HTTP Middleware function to enrich incoming request with context
  * - `opts.log` defaults to `true`, `false` to disable logging
  * - `opts.colors` defaults to `process.stdout.isTTY`, `true` to enable colors in logging
+ * - `opts.ignoreSelf` defaults to `true`, `true` to automatically ignore any messages from yourself. This flag requires the context to set `meta.app_bot_id` with the Slack App's users.profile.bot_id.
+ * - `opts.ignoreBots` defaults to `false`, `true` to ignore any messages from bot users automatically
  *
  * Example
  *

--- a/src/slapp.js
+++ b/src/slapp.js
@@ -142,7 +142,9 @@ class Slapp extends EventEmitter {
   ignoreSelfMiddleware () {
     return (msg, next) => {
       if (msg.isBot() && msg.isMessage() && msg.body.event.subtype === 'bot_message') {
-        if (msg.meta.app_bot_id === msg.meta.bot_id) {
+        let bothFalsy = !msg.meta.app_bot_id && !msg.meta.bot_id
+        let bothEqual = msg.meta.app_bot_id === msg.meta.bot_id
+        if (!bothFalsy && bothEqual) {
           return
         }
       }

--- a/test/slapp.test.js
+++ b/test/slapp.test.js
@@ -786,6 +786,27 @@ test.cb('Slapp.ignoreSelfMiddleware() without bot_message', t => {
   })
 })
 
+test.cb('Slapp.ignoreSelfMiddleware() both ids falsey', t => {
+  let app = new Slapp({ context })
+  let mw = app.ignoreSelfMiddleware()
+
+  let message = new Message('event', {
+    event: {
+      type: 'message',
+      subtype: 'bot_message'
+    }
+  }, {
+    bot_id: null,
+    app_bot_id: null
+  })
+
+  // this callback is synchronous
+  mw(message, () => {
+    t.pass()
+    t.end()
+  })
+})
+
 test.cb('Slapp.preprocessConversationMiddleware() w/ conversation', t => {
   t.plan(3)
 


### PR DESCRIPTION
- Adds ignoreSelfMiddleware() as default middleware, but this will only work if `meta.app_bot_id` is set by the context. You must use `slapp-context-beepboop` >= 1.3.0. 
- Added `opts.ignoreSelf` to configure this
- Makes ignoreBotsMiddleware() optional by default
- Added `opts.ignoreBots` to configure this, false by default
- Added tests around new middleware
- Updated README
- fixes #63 

This will require a new minor version