### PR TITLE
Automatically use Slash Command or Action responses before timeout

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -242,8 +242,9 @@ class Message {
 
   /**
    * Respond to a Slash command or interactive message action with a [`chat.postmessage`](https://api.slack.com/methods/chat.postMessage)
-   * payload. If `respond` is called within 3000ms of the original request, the original request will be responded to instead or using the
-   * `response_url`. This will keep the action button spinner in sync with an awaiting update and is about 25% more responsive when tested.
+   * payload. If `respond` is called within 2500ms of the original request (hard limit is 3000ms, consider 500ms as a buffer), the original
+   * request will be responded to instead or using the `response_url`. This will keep the action button spinner in sync with an awaiting
+   * update and is about 25% more responsive when tested.
    *
    * `input` options are the same as [`say`](#messagesay)
    *

--- a/src/message.js
+++ b/src/message.js
@@ -35,6 +35,9 @@ class Message {
 
     this._slapp = null
     this._queue = null
+
+    // allow clearTimeout to be stubbed
+    this.clearTimeout = clearTimeout
   }
 
   /**
@@ -77,6 +80,73 @@ class Message {
       }
     }
     return this
+  }
+
+  /**
+   * Attach response for cases the support responding directly to a request from Slack.
+   * This includes slash commands and message actions. If there is a response attached,
+   * `msg.respond` will use the request to respond, otherwise it will use the response_url
+   * to respond asynchronously. The `deadline` parameter controls how
+   * long to wait before timing out then close the HTTP request and fallback to the
+   * `response_url`.
+   *
+   * ##### Parameters
+   * - `response` fhttp response
+   * - `deadline` number of milliseconds before timing the response out
+   *
+   *
+   * ##### Returns
+   * - `this` (chainable)
+   *
+   * @param {Object} resp
+   * @param {number} deadline
+   * @api private
+   */
+  attachResponse (response, deadline) {
+    let self = this
+    self._response = response
+
+    self._responseTimeout = setTimeout(() => {
+      if (self._response && !self._response.headersSent) {
+        let response = self._response
+        self._response = undefined
+        self._responseTimeout = undefined
+        response.send()
+      }
+    }, deadline)
+
+    return this
+  }
+
+  /**
+   * Clears the attached response if it exists and returns that response,
+   * returns null otherwise. Also clear the timeout.
+   *
+   * ##### Parameters
+   * - `options` `Object` options object. Supports `close`, if true then close response
+   *
+   * ##### Returns `response` if attached, otherwise null
+   *
+   * @param {Object} options
+   *
+   * @api private
+   */
+  clearResponse (options) {
+    let self = this
+    options = options || {}
+    if (self._responseTimeout) {
+      self.clearTimeout(self._responseTimeout)
+      self._responseTimeout = undefined
+    }
+    if (self._response) {
+      let response = self._response
+      self._response = undefined
+      if (options.close) {
+        response.send()
+      }
+      return response
+    }
+    return null
   }
 
   /**
@@ -171,8 +241,10 @@ class Message {
   }
 
   /**
-   * Use a `response_url` from a Slash command or interactive message action with
-   * a [`chat.postmessage`](https://api.slack.com/methods/chat.postMessage) payload.
+   * Respond to a Slash command or interactive message action with a [`chat.postmessage`](https://api.slack.com/methods/chat.postMessage)
+   * payload. If `respond` is called within 3000ms of the original request, the original request will be responded to instead or using the
+   * `response_url`. This will keep the action button spinner in sync with an awaiting update and is about 25% more responsive when tested.
+   *
    * `input` options are the same as [`say`](#messagesay)
    *
    * ##### Parameters
@@ -214,6 +286,12 @@ class Message {
 
     if (!responseUrl) {
       return callback(new Error('responseUrl not provided or not included as response_url with this type of Slack event'))
+    }
+
+    let response = self.clearResponse()
+    if (response) {
+      response.send(input)
+      return callback(null, {})
     }
 
     self._queueRequest(() => {

--- a/src/receiver/index.js
+++ b/src/receiver/index.js
@@ -93,8 +93,19 @@ module.exports = class Receiver extends EventEmitter {
 
     let msg = new Message(message.type, message.body, message.meta)
 
+    if (message.response && message.responseTimeout) {
+      // Attaching the response will delegate responsibility of closing it
+      this.attachResponse(msg, message.response, message.responseTimeout)
+    } else {
+      res.send()
+    }
+
     this.emit('message', msg)
-    res.send()
+  }
+
+  attachResponse (msg, response, timeout) {
+    msg.attachResponse(response, timeout)
   }
 
 }
+

--- a/src/receiver/middleware/parse-action.js
+++ b/src/receiver/middleware/parse-action.js
@@ -27,7 +27,10 @@ module.exports = () => {
           user_id: body.user.id,
           channel_id: body.channel.id,
           team_id: body.team.id
-        }
+        },
+        // Message actions may be responded to directly within 3000ms
+        response: res,
+        responseTimeout: 2500
       }
 
       next()

--- a/src/receiver/middleware/parse-command.js
+++ b/src/receiver/middleware/parse-command.js
@@ -16,7 +16,10 @@ module.exports = () => {
           user_id: body.user_id,
           channel_id: body.channel_id,
           team_id: body.team_id
-        }
+        },
+        // Slash Commands requests may be responded to directly within 3000ms
+        response: res,
+        responseTimeout: 2500
       }
 
       next()

--- a/src/slapp.js
+++ b/src/slapp.js
@@ -244,6 +244,9 @@ class Slapp extends EventEmitter {
         }
       }
 
+      // no matchers
+      msg.clearResponse({ close: true })
+
       done(null, false)
     }
 

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -5,6 +5,7 @@ const sinon = require('sinon')
 const fs = require('fs')
 const fixtures = require('./fixtures/')
 const Receiver = require('../src/receiver/')
+const Message = require('../src/message')
 
 test('Receiver() w/ record', t => {
   let writeStub = sinon.stub(fs, 'writeFileSync', () => {})
@@ -97,6 +98,34 @@ test('Receiver.emitHandler() w/o debug', t => {
 
   t.true(emitStub.calledOnce)
   t.true(sendStub.calledOnce)
+})
+
+test('Receiver.emitHandler() attachResponse', t => {
+  let receiver = new Receiver()
+  let msg = getMockMessage()
+  let res = fixtures.getMockRes()
+
+  msg.response = res
+  msg.responseTimeout = 100
+
+  let emitStub = sinon.stub(receiver, 'emit')
+  let sendStub = sinon.stub(res, 'send')
+  let attachStub = sinon.stub(receiver, 'attachResponse')
+
+  receiver.emitHandler({ slapp: msg }, res, () => t.fail())
+  t.true(emitStub.calledOnce)
+  t.true(sendStub.notCalled)
+  t.true(attachStub.calledOnce)
+})
+
+test('Receiver.attachResponse()', t => {
+  let receiver = new Receiver()
+  let res = fixtures.getMockRes()
+  let msg = new Message()
+  let attachStub = sinon.stub(msg, 'attachResponse')
+
+  receiver.attachResponse(msg, res, 100)
+  t.true(attachStub.calledOnce)
 })
 
 function getMockMessage () {

--- a/test/slapp.test.js
+++ b/test/slapp.test.js
@@ -4,6 +4,7 @@ const test = require('ava').test
 const sinon = require('sinon')
 const Slapp = require('../src/slapp')
 const Message = require('../src/message')
+const fixtures = require('./fixtures/')
 
 const meta = {
   app_token: 'app_token',
@@ -241,6 +242,23 @@ test.cb('Slapp._handle() with override and del error', t => {
     t.true(delStub.calledWith(message.conversation_id))
     t.true(emitSpy.calledWith('error'))
 
+    t.end()
+  })
+})
+
+test.cb('Slapp._handle() w/ attached response', t => {
+  t.plan(2)
+
+  let app = new Slapp({ context })
+  let message = new Message('event', {}, meta)
+  let res = fixtures.getMockRes()
+  message.attachResponse(res, 100)
+
+  let clearResponseStub = sinon.stub(message, 'clearResponse')
+
+  app._handle(message, (err) => {
+    t.is(err, null)
+    t.true(clearResponseStub.calledOnce)
     t.end()
   })
 })


### PR DESCRIPTION
When dealing with Slash Commands or Message Action request, automatically leave the originating request open and respond to that request if `msg.respond` is called within a 2500ms timeout window. If the timeout lapses, the request will be closed and the `response_urll` will be used instead.

This change has no public API implications. Tests were updated to maintain full coverage.