### PR TITLE
Adds msg reply threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,9 +782,12 @@ It is generally always passed as `msg`.
   - [Message.cancel()](#messagecancel)
   - [Message.say()](#messagesayinputstringobjectarraycallbackfunction)
   - [Message.respond()](#messagerespondresponseurlstringinputstringobjectarraycallbackfunction)
+  - [Message.thread()](#messagethread)
+  - [Message.unthread()](#messageunthread)
   - [Message._request()](#message_request)
   - [Message.isBot()](#messageisbot)
   - [Message.isBaseMessage()](#messageisbasemessage)
+  - [Message.isThreaded()](#messageisthreaded)
   - [Message.isDirectMention()](#messageisdirectmention)
   - [Message.isDirectMessage()](#messageisdirectmessage)
   - [Message.isMention()](#messageismention)
@@ -833,6 +836,9 @@ It is generally always passed as `msg`.
   `string`, `Object` or mixed `Array` of `strings` and `Objects`. If a string,
   the value will be set to `text` of the `chat.postmessage` object. Otherwise pass
   a [`chat.postmessage`](https://api.slack.com/methods/chat.postMessage) `Object`.
+  If the current message is part of a thread, the new message will remain
+  in the thread. To control if a message is threaded or not you can use the
+  `msg.thread()` and `msg.unthread()` functions.
   
   If `input` is an `Array`, a random value in the array will be selected.
   
@@ -846,8 +852,11 @@ It is generally always passed as `msg`.
 
 ## Message.respond([responseUrl]:string, input:string|Object|Array, callback:function)
 
-  Use a `response_url` from a Slash command or interactive message action with
-  a [`chat.postmessage`](https://api.slack.com/methods/chat.postMessage) payload.
+  Respond to a Slash command or interactive message action with a [`chat.postmessage`](https://api.slack.com/methods/chat.postMessage)
+  payload. If `respond` is called within 2500ms of the original request (hard limit is 3000ms, consider 500ms as a buffer), the original
+  request will be responded to instead of using the `response_url`. This will keep the action button spinner in sync with an awaiting
+  update and is about 25% more responsive when tested.
+  
   `input` options are the same as [`say`](#messagesay)
   
 #### Parameters
@@ -885,6 +894,45 @@ It is generally always passed as `msg`.
 #### Returns
   - `this` (chainable)
 
+## Message.thread()
+
+  Ensures all subsequent messages created are under a thread of the current message
+  
+  Example:
+  
+```js
+  // current msg is not part of a thread (i.e. does not have thread_ts set)
+  msg.
+   .say('This message will not be part of the thread and will be in the channel')
+   .thread()
+   .say('This message will remain in the thread')
+   .say('This will also be in the thread')
+```
+
+  
+#### Returns
+  - `this` (chainable)
+
+## Message.unthread()
+
+  Ensures all subsequent messages created are not part of a thread
+  
+  Example:
+  
+```js
+  // current msg is part of a thread (i.e. has thread_ts set)
+  msg.
+   .say('This message will remain in the thread')
+   .unthread()
+   .say('This message will not be part of the thread and will be in the channel')
+   .say('This will also not be part of the thread')
+```
+
+  
+  
+#### Returns
+  - `this` (chainable)
+
 ## Message._request()
 
   istanbul ignore next
@@ -901,6 +949,13 @@ It is generally always passed as `msg`.
   
   
 #### Returns `bool` true if `this` is a message event type with no subtype
+
+## Message.isThreaded()
+
+  Is this an `event` of type `message` without any [subtype](https://api.slack.com/events/message)?
+  
+  
+#### Returns `bool` true if `this` is an event that is part of a thread
 
 ## Message.isDirectMention()
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "deap": "^1.0.0",
     "js-queue": "^1.0.0",
     "request": "^2.73.0",
-    "slack": "^7.5.7"
+    "slack": "^8.2.0"
   },
   "devDependencies": {
     "ava": "^0.15.2",

--- a/src/message.js
+++ b/src/message.js
@@ -27,6 +27,7 @@ class Message {
     this.type = type
     this.body = body || {}
     this.meta = meta || {}
+    this.makeThreaded = null
     this.conversation_id = [
       this.meta.team_id,
       this.meta.channel_id || 'nochannel',
@@ -202,6 +203,9 @@ class Message {
    * `string`, `Object` or mixed `Array` of `strings` and `Objects`. If a string,
    * the value will be set to `text` of the `chat.postmessage` object. Otherwise pass
    * a [`chat.postmessage`](https://api.slack.com/methods/chat.postMessage) `Object`.
+   * If the current message is part of a thread, the new message will remain
+   * in the thread. To control if a message is threaded or not you can use the
+   * `msg.thread()` and `msg.unthread()` functions.
    *
    * If `input` is an `Array`, a random value in the array will be selected.
    *
@@ -227,6 +231,13 @@ class Message {
       token: self.meta.bot_token || self.meta.app_token,
       channel: self.meta.channel_id
     }, input)
+
+    // keep the message threaded unless we've "unthreaded" it
+    if (this.isThreaded() && this.makeThreaded !== false) {
+      payload.thread_ts = this.body.event.thread_ts
+    } else if (this.makeThreaded === true) {
+      payload.thread_ts = this.body.event.ts
+    }
 
     self._queueRequest(() => {
       slack.chat.postMessage(payload, (err, data) => {
@@ -321,9 +332,51 @@ class Message {
     return self
   }
 
-  reply (input, callback) {
-    input.thread_ts = this.body.ts
-    return this.say(input, callback)
+  /**
+   * Ensures all subsequent messages created are under a thread of the current message
+   *
+   * Example:
+   *
+   *     // current msg is not part of a thread (i.e. does not have thread_ts set)
+   *     msg.
+   *      .say('This message will not be part of the thread and will be in the channel')
+   *      .thread()
+   *      .say('This message will remain in the thread')
+   *      .say('This will also be in the thread')
+   *
+   * ##### Returns
+   * - `this` (chainable)
+   *
+   */
+
+  thread () {
+    this.makeThreaded = true
+
+    return this
+  }
+
+  /**
+   * Ensures all subsequent messages created are not part of a thread
+   *
+   * Example:
+   *
+   *     // current msg is part of a thread (i.e. has thread_ts set)
+   *     msg.
+   *      .say('This message will remain in the thread')
+   *      .unthread()
+   *      .say('This message will not be part of the thread and will be in the channel')
+   *      .say('This will also not be part of the thread')
+   *
+   *
+   * ##### Returns
+   * - `this` (chainable)
+   *
+   */
+
+  unthread () {
+    this.makeThreaded = false
+
+    return this
   }
 
   // TODO: PR this into smallwins/slack, below inspired by https://github.com/smallwins/slack/blob/master/src/_exec.js#L20
@@ -367,6 +420,17 @@ class Message {
 
   isBaseMessage () {
     return this.isMessage() && !this.body.event.subtype
+  }
+
+  /**
+   * Is this an `event` of type `message` without any [subtype](https://api.slack.com/events/message)?
+   *
+   *
+   * ##### Returns `bool` true if `this` is an event that is part of a thread
+   */
+
+  isThreaded () {
+    return this.body.event && !!this.body.event.thread_ts
   }
 
   /**

--- a/src/message.js
+++ b/src/message.js
@@ -243,7 +243,7 @@ class Message {
   /**
    * Respond to a Slash command or interactive message action with a [`chat.postmessage`](https://api.slack.com/methods/chat.postMessage)
    * payload. If `respond` is called within 2500ms of the original request (hard limit is 3000ms, consider 500ms as a buffer), the original
-   * request will be responded to instead or using the `response_url`. This will keep the action button spinner in sync with an awaiting
+   * request will be responded to instead of using the `response_url`. This will keep the action button spinner in sync with an awaiting
    * update and is about 25% more responsive when tested.
    *
    * `input` options are the same as [`say`](#messagesay)
@@ -319,6 +319,11 @@ class Message {
     })
 
     return self
+  }
+
+  reply (input, callback) {
+    input.thread_ts = this.body.ts
+    return this.say(input, callback)
   }
 
   // TODO: PR this into smallwins/slack, below inspired by https://github.com/smallwins/slack/blob/master/src/_exec.js#L20

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -350,6 +350,113 @@ test('Message.say() api error', t => {
   slack.chat.postMessage.restore()
 })
 
+test('Message.say() from threaded message', t => {
+  t.plan(5)
+
+  let meta = {
+    bot_token: 'bot_token',
+    app_token: 'app_token',
+    channel_id: 'channel_id'
+  }
+  let body = {
+    event: {
+      thread_ts: 123123123
+    }
+  }
+  let msg = new Message('event', body, meta)
+  let input = 'beepboop'
+  let postStub = sinon.stub(slack.chat, 'postMessage', (payload) => {
+    t.is(payload.text, input)
+    t.is(payload.token, meta.bot_token)
+    t.is(payload.channel, meta.channel_id)
+    t.is(payload.thread_ts, body.event.thread_ts)
+  })
+
+  msg.say(input)
+
+  t.true(postStub.calledOnce)
+  slack.chat.postMessage.restore()
+})
+
+test('Message.say() from non-threaded message', t => {
+  t.plan(5)
+
+  let meta = {
+    bot_token: 'bot_token',
+    app_token: 'app_token',
+    channel_id: 'channel_id'
+  }
+  let msg = new Message('event', {}, meta)
+  let input = 'beepboop'
+  let postStub = sinon.stub(slack.chat, 'postMessage', (payload) => {
+    t.is(payload.text, input)
+    t.is(payload.token, meta.bot_token)
+    t.is(payload.channel, meta.channel_id)
+    t.is(payload.thread_ts, undefined)
+  })
+
+  msg.say(input)
+
+  t.true(postStub.calledOnce)
+  slack.chat.postMessage.restore()
+})
+
+test('Message.thread().say() from non-threaded message', t => {
+  t.plan(5)
+
+  let meta = {
+    bot_token: 'bot_token',
+    app_token: 'app_token',
+    channel_id: 'channel_id'
+  }
+  let body = {
+    event: {
+      ts: 1232131231
+    }
+  }
+  let msg = new Message('event', body, meta)
+  let input = 'beepboop'
+  let postStub = sinon.stub(slack.chat, 'postMessage', (payload) => {
+    t.is(payload.text, input)
+    t.is(payload.token, meta.bot_token)
+    t.is(payload.channel, meta.channel_id)
+    t.is(payload.thread_ts, body.event.ts)
+  })
+
+  msg.thread().say(input)
+
+  t.true(postStub.calledOnce)
+  slack.chat.postMessage.restore()
+})
+
+test('Message.unthread().say() from threaded message', t => {
+  t.plan(5)
+
+  let meta = {
+    bot_token: 'bot_token',
+    app_token: 'app_token',
+    channel_id: 'channel_id'
+  }
+  let body = {
+    event: {
+      thread_ts: 1232131231
+    }
+  }
+  let msg = new Message('event', body, meta)
+  let input = 'beepboop'
+  let postStub = sinon.stub(slack.chat, 'postMessage', (payload) => {
+    t.is(payload.text, input)
+    t.is(payload.token, meta.bot_token)
+    t.is(payload.channel, meta.channel_id)
+    t.is(payload.thread_ts, undefined)
+  })
+
+  msg.unthread().say(input)
+
+  t.true(postStub.calledOnce)
+  slack.chat.postMessage.restore()
+})
+
 test.cb('Message.respond()', t => {
   t.plan(5)
 


### PR DESCRIPTION
This PR adds support for threaded messages in Slack.

It slightly changes the behavior of `Message.say()` in that if a message is part of a thread, the default is that any newly created messages would remain in that thread.  You can control this behavior explicitly via `Message.thread()` and `Message.unthread()`.  For example:

In the case where `msg` is not part of an existing thread:

```js
msg.
  .say('This message will not be part of the thread and will be in the channel')
  .thread()
  .say('This message will remain in the thread')
  .say('This will also be in the thread')
```

The opposite is also true for unthreading a message that is part of a thread:

```js
msg.
  .say('This message will remain in the thread')
  .unthread()
  .say('This message will not be part of the thread and will be in the channel')
  .say('This will also not be part of the thread')
```

Due to this change in `Message.say()` this will be released as a major version bump for slapp.

Also of note, the `smallwins/slack` client has been updated to the latest version, which supports new threaded message endpoints.