### PR TITLE
Adds msg.isAuthedTeam()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1001,10 +1001,10 @@ It is generally always passed as `msg`.
 ## Message.isAuthedTeam()
 
   Return true if the event "team_id" is included in the "authed_teams" array.
-  In other worse, this event originated from a team who has installed your app
+  In other words, this event originated from a team who has installed your app
   versus a team who is sharing a channel with a team who has installed the app
   but in fact hasn't installed the app into that team explicitly.
-  There are some events that do not include an "auth_teams" property. In these
+  There are some events that do not include an "authed_teams" property. In these
   cases, error on the side of claiming this IS from an authed team.
   
 #### Returns an Array of user IDs

--- a/README.md
+++ b/README.md
@@ -793,6 +793,7 @@ It is generally always passed as `msg`.
   - [Message.isMention()](#messageismention)
   - [Message.isAmbient()](#messageisambient)
   - [Message.isAnyOf()](#messageisanyofofarray)
+  - [Message.isAuthedTeam()](#messageisauthedteam)
   - [Message.usersMentioned()](#messageusersmentioned)
   - [Message.channelsMentioned()](#messagechannelsmentioned)
   - [Message.subteamGroupsMentioned()](#messagesubteamgroupsmentioned)
@@ -996,6 +997,17 @@ It is generally always passed as `msg`.
   
   
 #### Returns `bool` true if `this` is a message that matches any of the filters
+
+## Message.isAuthedTeam()
+
+  Return true if the event "team_id" is included in the "authed_teams" array.
+  In other worse, this event originated from a team who has installed your app
+  versus a team who is sharing a channel with a team who has installed the app
+  but in fact hasn't installed the app into that team explicitly.
+  There are some events that do not include an "auth_teams" property. In these
+  cases, error on the side of claiming this IS from an authed team.
+  
+#### Returns an Array of user IDs
 
 ## Message.usersMentioned()
 

--- a/src/message.js
+++ b/src/message.js
@@ -506,6 +506,25 @@ class Message {
   }
 
   /**
+   * Return true if the event "team_id" is included in the "authed_teams" array.
+   * In other worse, this event originated from a team who has installed your app
+   * versus a team who is sharing a channel with a team who has installed the app
+   * but in fact hasn't installed the app into that team explicitly.
+   * There are some events that do not include an "auth_teams" property. In these
+   * cases, error on the side of claiming this IS from an authed team.
+   *
+   * ##### Returns an Array of user IDs
+   */
+
+  isAuthedTeam () {
+    // if the authed_teams property does not exist, error on the side of claiming it is an authed team_id
+    if (!Array.isArray(this.body.authed_teams)) {
+      return true
+    }
+    return this.body.authed_teams.indexOf(this.body.team_id) >= 0
+  }
+
+  /**
    * Return the user IDs of any users mentioned in the message
    *
    * ##### Returns an Array of user IDs

--- a/src/message.js
+++ b/src/message.js
@@ -507,10 +507,10 @@ class Message {
 
   /**
    * Return true if the event "team_id" is included in the "authed_teams" array.
-   * In other worse, this event originated from a team who has installed your app
+   * In other words, this event originated from a team who has installed your app
    * versus a team who is sharing a channel with a team who has installed the app
    * but in fact hasn't installed the app into that team explicitly.
-   * There are some events that do not include an "auth_teams" property. In these
+   * There are some events that do not include an "authed_teams" property. In these
    * cases, error on the side of claiming this IS from an authed team.
    *
    * ##### Returns an Array of user IDs

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -777,6 +777,32 @@ test('Message.isDirectMention() false', t => {
   t.false(msg.isDirectMention())
 })
 
+test('Message.isAuthedTeam()', t => {
+  let msg = new Message('event', {
+    team_id: 'team_id1',
+    authed_teams: ['team_id1', 'team_id2']
+  })
+
+  t.true(msg.isAuthedTeam())
+})
+
+test('Message.isAuthedTeam() false', t => {
+  let msg = new Message('event', {
+    team_id: 'team_id1',
+    authed_teams: ['team_id2', 'team_id3']
+  })
+
+  t.false(msg.isAuthedTeam())
+})
+
+test('Message.isAuthedTeam() authed_teams missing', t => {
+  let msg = new Message('event', {
+    team_id: 'team_id1'
+  })
+
+  t.true(msg.isAuthedTeam())
+})
+
 test('Message.stripDirectMention()', t => {
   let botUserId = 'bot_user_id'
   let msg = new Message('event', {


### PR DESCRIPTION
Adds a check on `msg` to tell you if this event came from a team who has installed the app. There's a change the team hasn't installed your app because it is being used through another team that has shared a channel with that team. This check help identifies that situation. However it does fall back to returning `true` even when it doesn't know to maintain some sense of reverse compatibility. 