### PR TITLE
Allow events without app_token to pass through

### DIFF
--- a/src/slapp.js
+++ b/src/slapp.js
@@ -206,7 +206,6 @@ class Slapp extends EventEmitter {
     let err = msg.verifyProps()
     if (err) {
       self.emit('error', err)
-      return done(err, false)
     }
 
     this.emit('info', this.formatter(msg))

--- a/test/slapp.test.js
+++ b/test/slapp.test.js
@@ -137,7 +137,7 @@ test.cb('Slapp._handle() w/ a bad message', t => {
 
   let emitSpy = sinon.stub(app, 'emit')
   app._handle(message, (err) => {
-    t.not(err, null)
+    t.is(err, null)
     t.true(emitSpy.calledWith('error'))
     t.end()
   })


### PR DESCRIPTION
This is an interesting edge case. This change allows messages that fail `msg.verifyProps()` to continue to be processed. This will allow events like `bb.team_removed` events to properly propagate through the router without being blocked. An error is still emitted but it continues processing. 

If this situation ever occurs there's either a larger problem hydrating the context or it is intentional. In the latter case, we still emit an error.

See any issues with this approach?