### PR TITLE
pegging coveralls version to test change in reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "npm run lint && npm run coverage",
     "lint": "standard",
     "unit": "ava --verbose --serial",
-    "coverage": "nyc --check-coverage --statements 100 ava --verbose --serial",
+    "coverage": "nyc --check-coverage --branches 100 ava --verbose --serial",
     "lcov": "nyc --reporter lcov ava --serial",
     "docs": "node scripts/docs.js",
     "coveralls": "npm run lcov && cat ./coverage/lcov.info | coveralls"
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "ava": "^0.15.2",
-    "coveralls": "^2.11.11",
+    "coveralls": "2.11.11",
     "dox": "^0.8.1",
     "nyc": "^7.0.0",
     "sinon": "^1.17.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "npm run lint && npm run coverage",
     "lint": "standard",
     "unit": "ava --verbose --serial",
-    "coverage": "nyc --check-coverage --branches 100 ava --verbose --serial",
+    "coverage": "nyc --check-coverage --statements 100 ava --verbose --serial",
     "lcov": "nyc --reporter lcov ava --serial",
     "docs": "node scripts/docs.js",
     "coveralls": "npm run lcov && cat ./coverage/lcov.info | coveralls"


### PR DESCRIPTION
More recent versions of `coveralls` have started including branches as part of the coverage report calculation.  It would be great to get 100% coverage for branches too, but to keep things functioning as they were I'm pegging the version to where it was.  We can decide if we want to go forward w/ 100% branch coverage as well, and then bump up the version of `coveralls` to reflect that.