### PR TITLE
Adding support for user object in event payload as opposed to a user id string.

### DIFF
--- a/src/receiver/middleware/parse-event.js
+++ b/src/receiver/middleware/parse-event.js
@@ -20,13 +20,20 @@ module.exports = () => {
       let body = req.body || {}
       let event = body.event || {}
       let channelId = event.channel || (event.item && event.item.channel)
+      let userId
+
+      if (typeof event.user === 'string') {
+        userId = event.user
+      } else if (typeof event.user === 'object') {
+        userId = event.user.id
+      }
 
       req.slapp = {
         type: 'event',
         body: body,
         meta: {
           verify_token: body.token,
-          user_id: event.user,
+          user_id: userId,
           bot_id: event.bot_id,
           channel_id: channelId,
           team_id: body.team_id

--- a/test/middleware.parse-event.test.js
+++ b/test/middleware.parse-event.test.js
@@ -47,6 +47,25 @@ test.cb('ParseEvent() with payload', t => {
   })
 })
 
+test.cb('ParseEvent() with user change payload', t => {
+  let mw = ParseEvent().pop()
+  let payload = mockUserChangePayload()
+  let req = { body: payload }
+
+  mw(req, {}, () => {
+    let slapp = req.slapp
+
+    t.is(slapp.type, 'event')
+    t.deepEqual(slapp.body, req.body)
+    t.is(slapp.meta.verify_token, payload.token)
+    t.is(slapp.meta.user_id, payload.event.user.id)
+    t.is(slapp.meta.bot_id, payload.event.bot_id)
+    t.is(slapp.meta.channel_id, payload.event.channel)
+    t.is(slapp.meta.team_id, payload.team_id)
+    t.end()
+  })
+})
+
 test('ParseEvent() challenge request', t => {
   let mw = ParseEvent()[1]
 
@@ -72,6 +91,21 @@ function mockPayload () {
     token: 'token',
     event: {
       user: 'user_id',
+      bot_id: 'bot_id',
+      channel: 'channel_id'
+    },
+    team_id: 'team_id'
+  }
+}
+
+function mockUserChangePayload () {
+  return {
+    token: 'token',
+    event: {
+      user: {
+        id: 'user_id',
+        team_id: 'team_id'
+      },
       bot_id: 'bot_id',
       channel: 'channel_id'
     },


### PR DESCRIPTION
Fixes issue #84 

If any extra standard data is expected to be gleaned from the user object, it can be added in that new mock response.