### PR TITLE
Fixes undefined reference when event user is null

### DIFF
--- a/src/receiver/middleware/parse-event.js
+++ b/src/receiver/middleware/parse-event.js
@@ -24,7 +24,7 @@ module.exports = () => {
 
       if (typeof event.user === 'string') {
         userId = event.user
-      } else if (typeof event.user === 'object') {
+      } else if (!!event.user && typeof event.user === 'object') {
         userId = event.user.id
       }
 

--- a/test/middleware.parse-event.test.js
+++ b/test/middleware.parse-event.test.js
@@ -66,6 +66,25 @@ test.cb('ParseEvent() with user change payload', t => {
   })
 })
 
+test.cb('ParseEvent() with no user in payload', t => {
+  let mw = ParseEvent().pop()
+  let payload = mockNoUserPayload()
+  let req = { body: payload }
+
+  mw(req, {}, () => {
+    let slapp = req.slapp
+
+    t.is(slapp.type, 'event')
+    t.deepEqual(slapp.body, req.body)
+    t.is(slapp.meta.verify_token, payload.token)
+    t.is(slapp.meta.user_id, undefined)
+    t.is(slapp.meta.bot_id, payload.event.bot_id)
+    t.is(slapp.meta.channel_id, payload.event.channel)
+    t.is(slapp.meta.team_id, payload.team_id)
+    t.end()
+  })
+})
+
 test('ParseEvent() challenge request', t => {
   let mw = ParseEvent()[1]
 
@@ -106,6 +125,17 @@ function mockUserChangePayload () {
         id: 'user_id',
         team_id: 'team_id'
       },
+      bot_id: 'bot_id',
+      channel: 'channel_id'
+    },
+    team_id: 'team_id'
+  }
+}
+
+function mockNoUserPayload () {
+  return {
+    token: 'token',
+    event: {
       bot_id: 'bot_id',
       channel: 'channel_id'
     },


### PR DESCRIPTION
`typeof null` returns `object` (thanks JS 🙄). This fixes an attempt to reference `id` on a null `user` object in a non-user event.