### PR TITLE
Bump smallwins/slack to 11.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6848,11 +6848,18 @@
       }
     },
     "slack": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/slack/-/slack-9.1.2.tgz",
-      "integrity": "sha512-qfvCAcemIxNFVPsBH5g9ykEmUI/+nprdSD6t6SbMSuItTeZTjuZ0pIfxS1I/3+1SeaKZJCU+srFqfYcHccvcLA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/slack/-/slack-11.0.0.tgz",
+      "integrity": "sha512-GSu9DgFftK89U+mXUCTZZmBvpEfnTTGoUgXNtjrUfVvQ4+lHRWgtM2GU0Oqc3sMQ9tQz4e3+3eC5NPEcXyjq/A==",
       "requires": {
-        "tiny-json-http": "5.3.2"
+        "tiny-json-http": "7.0.0"
+      },
+      "dependencies": {
+        "tiny-json-http": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/tiny-json-http/-/tiny-json-http-7.0.0.tgz",
+          "integrity": "sha512-g3S2RiSmoZDJOMDTX6uj8GjVsiH4s0W0tb1YKYARoP4cosgIb4CB2i7Cdzn9UJqOrI1b1aNK+cgScPx4TwolQg=="
+        }
       }
     },
     "slash": {
@@ -7230,11 +7237,6 @@
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
       "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
       "dev": true
-    },
-    "tiny-json-http": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/tiny-json-http/-/tiny-json-http-5.3.2.tgz",
-      "integrity": "sha512-aACNqxtULveH36S0RKiQ/tvB9tiihvSyWac0JgbRihfYaSJAz42/5z++pdY0KWMsti7rq0Uagc7YDa2+EmrZPw=="
     },
     "to-fast-properties": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "js-queue": "^1.0.0",
     "path-to-regexp": "^2.0.0",
     "request": "^2.73.0",
-    "slack": "^9.1.2"
+    "slack": "^11.0.0"
   },
   "devDependencies": {
     "ava": "^0.15.2",


### PR DESCRIPTION
Security fix for https://nvd.nist.gov/vuln/detail/CVE-2018-1000096

May warrant a major revision release as people may have been depending on the default behavior of trusting invalid SSL certs. Tested locally on a Slapp project and everything works. 